### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe shell command constructed from library input

### DIFF
--- a/packages/build-utils/src/exec.ts
+++ b/packages/build-utils/src/exec.ts
@@ -59,7 +59,6 @@ export async function exec({
 
     const childProcess = spawn(spawnCommand, spawnArgs, {
       cwd,
-      shell: true,
       env,
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Gigadrive/sdk/security/code-scanning/3](https://github.com/Gigadrive/sdk/security/code-scanning/3)

To fix the problem, we should avoid using the `shell: true` option with `spawn` and instead use `spawn` without the shell option. This requires ensuring that the command and its arguments are passed as an array, which prevents the shell from interpreting special characters.

- Modify the `exec` function to use `spawn` without the `shell: true` option.
- Ensure that the `command` input is properly split into the command and its arguments.
- Update the `spawn` call to use the command and arguments directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
