### PR TITLE
feat: add disableVersionCheck option to parseRawConfig

### DIFF
--- a/.changeset/bright-crabs-lose.md
+++ b/.changeset/bright-crabs-lose.md
@@ -1,0 +1,5 @@
+---
+'@gigadrive/network-config': patch
+---
+
+fix invalid version check on Vercel Build Output API v3 files

--- a/packages/network-config/src/build-output-v3/parse.ts
+++ b/packages/network-config/src/build-output-v3/parse.ts
@@ -164,7 +164,7 @@ export const readConfigFile = async <T>(configFilePath: string): Promise<T | nul
     return null;
   }
 
-  const parsed = await parseRawConfig(configFilePath);
+  const parsed = await parseRawConfig(configFilePath, { disableVersionCheck: true });
 
   return parsed as T;
 };

--- a/packages/network-config/src/parse-raw-config.test.ts
+++ b/packages/network-config/src/parse-raw-config.test.ts
@@ -85,4 +85,9 @@ describe('parseRawConfig', () => {
       `Config file is missing version at ${noVersionFilePath}`
     );
   });
+
+  test('should not throw error for file without version when disableVersionCheck is true', async () => {
+    const result = await parseRawConfig(noVersionFilePath, { disableVersionCheck: true });
+    expect(result).toEqual({ name: 'test-no-version' });
+  });
 });

--- a/packages/network-config/src/parse-raw-config.ts
+++ b/packages/network-config/src/parse-raw-config.ts
@@ -2,7 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import { parse as parseYaml } from 'yaml';
 
-export const parseRawConfig = async (filePath: string): Promise<any> => {
+export const parseRawConfig = async (
+  filePath: string,
+  { disableVersionCheck = false }: { disableVersionCheck?: boolean } = {}
+): Promise<any> => {
   // check if the file exists
   if (!fs.existsSync(filePath)) {
     throw new Error(`Config file not found at ${filePath}`);
@@ -40,7 +43,7 @@ export const parseRawConfig = async (filePath: string): Promise<any> => {
   }
 
   // check if the version is present
-  if (typeof parsed.version !== 'number') {
+  if (!disableVersionCheck && typeof parsed.version !== 'number') {
     throw new Error(`Config file is missing version at ${filePath}`);
   }
 


### PR DESCRIPTION
this is necessary as files for Vercel Build Output API v3 incorrectly checked for a version, even though they are not supposed to have one