### PR TITLE
chore: remove inter-ui dependency

### DIFF
--- a/.changeset/mean-rocks-wait.md
+++ b/.changeset/mean-rocks-wait.md
@@ -1,0 +1,5 @@
+---
+'@gigadrive/harmony': patch
+---
+
+remove inter-ui dependency

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -77,7 +77,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.7.4",
-    "inter-ui": "^3.19.3",
     "lucide-react": "^0.503.0",
     "nanoid": "^5.1.5",
     "next-themes": "^0.4.6",

--- a/packages/harmony/src/index.ts
+++ b/packages/harmony/src/index.ts
@@ -1,5 +1,4 @@
 import '@fontsource/manrope';
-import 'inter-ui/inter.css';
 import './index.css';
 
 export * from './hooks';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,9 +297,6 @@ importers:
       framer-motion:
         specifier: ^12.7.4
         version: 12.9.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      inter-ui:
-        specifier: ^3.19.3
-        version: 3.19.3
       lucide-react:
         specifier: ^0.503.0
         version: 0.503.0(react@18.3.1)
@@ -3712,9 +3709,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  inter-ui@3.19.3:
-    resolution: {integrity: sha512-5FG9fjuYOXocIfjzcCBhICL5cpvwEetseL3FU6tP3d6Bn7g8wODhB+I9RNGRTizCT7CUG4GOK54OPxqq3msQgg==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -9135,8 +9129,6 @@ snapshots:
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
-
-  inter-ui@3.19.3: {}
 
   internal-slot@1.1.0:
     dependencies:


### PR DESCRIPTION
Default behavior is to use Resist Sans, Inter can be installed by developers who wish to use it.