### PR TITLE
feat(network-config): improve framework packaging metadata

### DIFF
--- a/.changeset/fuzzy-ravens-package.md
+++ b/.changeset/fuzzy-ravens-package.md
@@ -1,0 +1,5 @@
+---
+'@gigadrive/network-config': minor
+---
+
+Add package include/exclude metadata to normalized function entrypoints, refine NestJS output path detection from `nest-cli.json`, and use Composer for detected PHP frameworks even when JavaScript lockfiles are present.

--- a/packages/network-config/src/detection/detect-framework.test.ts
+++ b/packages/network-config/src/detection/detect-framework.test.ts
@@ -34,21 +34,6 @@ describe('detectFramework', () => {
     expect(result.framework.slug).toBe('nuxt');
   });
 
-  it('should detect NestJS from package.json', async () => {
-    const fs = makeTestFs({
-      '/project/package.json': JSON.stringify({
-        dependencies: { '@nestjs/core': '^10.0.0', express: '^4.0.0' },
-      }),
-    });
-
-    const result = await Effect.runPromise(
-      detectFramework('/project').pipe(Effect.provide(Layer.merge(fs, TestPathLayer)))
-    );
-
-    // NestJS has higher priority than Express
-    expect(result.framework.slug).toBe('nestjs');
-  });
-
   it('should detect Laravel from composer.json + artisan file', async () => {
     const fs = makeTestFs({
       '/project/composer.json': JSON.stringify({

--- a/packages/network-config/src/detection/detect-framework.ts
+++ b/packages/network-config/src/detection/detect-framework.ts
@@ -115,8 +115,13 @@ export const detectFramework = Effect.fn('detectFramework')(function* (projectFo
     if (matches) {
       yield* Effect.log(`Detected framework: ${framework.name}`, { slug: framework.slug });
 
-      const packageManager = yield* detectPackageManager(projectFolder);
-      const config = yield* generateConfig(framework, packageManager);
+      const detectedPackageManager = yield* detectPackageManager(projectFolder);
+      const packageManager = framework.language === 'php' ? 'composer' : detectedPackageManager;
+      const defaults = framework.getDefaultConfig(packageManager);
+      const refinedDefaults = framework.refineDefaultConfig
+        ? yield* framework.refineDefaultConfig(defaults, projectFolder)
+        : defaults;
+      const config = yield* generateConfig(framework, packageManager, refinedDefaults);
 
       return { framework, packageManager, config } as DetectionResult;
     }

--- a/packages/network-config/src/detection/detect-package-manager.test.ts
+++ b/packages/network-config/src/detection/detect-package-manager.test.ts
@@ -48,4 +48,55 @@ describe('detectPackageManager', () => {
     const result = await run({ '/project/bun.lockb': '', '/project/pnpm-lock.yaml': '' });
     expect(result).toBe('bun');
   });
+
+  it('should prefer bun.lock over all non-Bun lockfiles', async () => {
+    const result = await run({
+      '/project/bun.lock': '',
+      '/project/pnpm-lock.yaml': '',
+      '/project/yarn.lock': '',
+      '/project/package-lock.json': '',
+      '/project/composer.lock': '',
+    });
+
+    expect(result).toBe('bun');
+  });
+
+  it('should prefer pnpm over yarn, npm, and composer lockfiles', async () => {
+    const result = await run({
+      '/project/pnpm-lock.yaml': '',
+      '/project/yarn.lock': '',
+      '/project/package-lock.json': '',
+      '/project/composer.lock': '',
+    });
+
+    expect(result).toBe('pnpm');
+  });
+
+  it('should prefer yarn over npm and composer lockfiles', async () => {
+    const result = await run({
+      '/project/yarn.lock': '',
+      '/project/package-lock.json': '',
+      '/project/composer.lock': '',
+    });
+
+    expect(result).toBe('yarn');
+  });
+
+  it('should prefer npm over composer lockfiles', async () => {
+    const result = await run({
+      '/project/package-lock.json': '',
+      '/project/composer.lock': '',
+    });
+
+    expect(result).toBe('npm');
+  });
+
+  it('should ignore lockfiles outside the project root', async () => {
+    const result = await run({
+      '/pnpm-lock.yaml': '',
+      '/project/package.json': '',
+    });
+
+    expect(result).toBe('npm');
+  });
 });

--- a/packages/network-config/src/detection/frameworks/astro.test.ts
+++ b/packages/network-config/src/detection/frameworks/astro.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { astro: '^5.0.0' };
+
+describe('Astro framework detection', () => {
+  expectNodePackageManagerVariants('Astro', dependencies, 'astro build');
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Astro and generate server/client build config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/bun.lockb': '',
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'astro', name: 'Astro' });
+    expect(result.packageManager).toBe('bun');
+    expect(result.config.commands).toEqual(['bun install', 'astro build']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'dist/server/entry.mjs',
+        runtime: 'node-22',
+        memory: 256,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([
+      expect.objectContaining({ path: '/*', destination: 'dist/server/entry.mjs' }),
+    ]);
+    expect(result.config.assets).toMatchObject({ prefixToStrip: 'dist/client/', populateCache: true });
+  });
+
+  it('should prefer Astro over Vite', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson({ ...dependencies, vite: '^7.0.0' }),
+    });
+
+    expect(result.framework.slug).toBe('astro');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/elysia.test.ts
+++ b/packages/network-config/src/detection/frameworks/elysia.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { elysia: '^1.0.0' };
+
+describe('Elysia framework detection', () => {
+  expectNodePackageManagerVariants('Elysia', dependencies);
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Elysia and generate Bun server config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/bun.lockb': '',
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'elysia', name: 'Elysia' });
+    expect(result.packageManager).toBe('bun');
+    expect(result.config.commands).toEqual(['bun install']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'src/index.ts',
+        runtime: 'bun-1',
+        memory: 128,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([expect.objectContaining({ path: '/*', destination: 'src/index.ts' })]);
+  });
+
+  it('should prefer Elysia over Fastify and Express', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson({ ...dependencies, fastify: '^5.0.0', express: '^4.0.0' }),
+    });
+
+    expect(result.framework.slug).toBe('elysia');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/express.test.ts
+++ b/packages/network-config/src/detection/frameworks/express.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { express: '^4.0.0' };
+
+describe('Express framework detection', () => {
+  expectNodePackageManagerVariants('Express', dependencies);
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Express and generate index.js server config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'express', name: 'Express' });
+    expect(result.config.commands).toEqual(['npm install']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'index.js',
+        runtime: 'node-22',
+        memory: 128,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([expect.objectContaining({ path: '/*', destination: 'index.js' })]);
+    expect(result.config.assets).toBeUndefined();
+  });
+});

--- a/packages/network-config/src/detection/frameworks/fastify.test.ts
+++ b/packages/network-config/src/detection/frameworks/fastify.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { fastify: '^5.0.0' };
+
+describe('Fastify framework detection', () => {
+  expectNodePackageManagerVariants('Fastify', dependencies);
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Fastify and generate src/index.ts server config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'fastify', name: 'Fastify' });
+    expect(result.config.commands).toEqual(['npm install']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'src/index.ts',
+        runtime: 'node-22',
+        memory: 128,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([expect.objectContaining({ path: '/*', destination: 'src/index.ts' })]);
+  });
+
+  it('should prefer Fastify over Express', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson({ ...dependencies, express: '^4.0.0' }),
+    });
+
+    expect(result.framework.slug).toBe('fastify');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/hono.test.ts
+++ b/packages/network-config/src/detection/frameworks/hono.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { hono: '^4.0.0' };
+
+describe('Hono framework detection', () => {
+  expectNodePackageManagerVariants('Hono', dependencies);
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Hono and generate src/index.ts server config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/pnpm-lock.yaml': '',
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'hono', name: 'Hono' });
+    expect(result.packageManager).toBe('pnpm');
+    expect(result.config.commands).toEqual(['pnpm install']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'src/index.ts',
+        runtime: 'node-22',
+        memory: 128,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([expect.objectContaining({ path: '/*', destination: 'src/index.ts' })]);
+  });
+
+  it('should prefer Hono over Fastify and Express', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson({ ...dependencies, fastify: '^5.0.0', express: '^4.0.0' }),
+    });
+
+    expect(result.framework.slug).toBe('hono');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/laravel.test.ts
+++ b/packages/network-config/src/detection/frameworks/laravel.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { composerJson, detectProject, detectProjectError } from './test-utils';
+
+const lockfileCases: Array<{ name: string; lockfile: Record<string, string> }> = [
+  { name: 'no lockfile', lockfile: {} },
+  { name: 'composer.lock', lockfile: { '/project/composer.lock': '' } },
+  { name: 'package-lock.json', lockfile: { '/project/package-lock.json': '' } },
+  { name: 'pnpm-lock.yaml', lockfile: { '/project/pnpm-lock.yaml': '' } },
+  { name: 'bun.lockb', lockfile: { '/project/bun.lockb': '' } },
+];
+
+describe('Laravel framework detection', () => {
+  it.each(lockfileCases)('should use composer install for Laravel projects with $name', async ({ lockfile }) => {
+    const result = await detectProject({
+      '/project/composer.json': composerJson({ php: '^8.3', 'laravel/framework': '^11.0' }),
+      '/project/artisan': '#!/usr/bin/env php',
+      ...lockfile,
+    });
+
+    expect(result.packageManager).toBe('composer');
+    expect(result.config.commands[0]).toBe('composer install');
+  });
+
+  it('should detect Laravel and generate public PHP entrypoint config', async () => {
+    const result = await detectProject({
+      '/project/composer.json': composerJson({ php: '^8.3', 'laravel/framework': '^11.0' }),
+      '/project/artisan': '#!/usr/bin/env php',
+      '/project/composer.lock': '',
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'laravel', name: 'Laravel' });
+    expect(result.packageManager).toBe('composer');
+    expect(result.config.commands).toEqual([
+      'composer install',
+      'composer require bref/laravel-bridge --update-with-dependencies',
+      'bun install',
+      'bun run build',
+    ]);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'public/index.php',
+        runtime: 'php-84',
+        memory: 256,
+        maxDuration: 30,
+        streaming: false,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([expect.objectContaining({ path: '/*', destination: 'public/index.php' })]);
+    expect(result.config.assets).toMatchObject({ prefixToStrip: 'public/', populateCache: true });
+    expect(result.config.excludeFiles).toEqual(['tests/', 'storage/', '.ddev', 'node_modules/']);
+    expect(result.config.environmentVariables).toMatchObject({
+      APP_ENV: 'production',
+      APP_DEBUG: 'false',
+      LOG_CHANNEL: 'stderr',
+      SESSION_DRIVER: 'cookie',
+    });
+  });
+
+  it('should require the artisan file in addition to laravel/framework', async () => {
+    const result = await detectProjectError({
+      '/project/composer.json': composerJson({ 'laravel/framework': '^11.0' }),
+    });
+
+    expect(result).toHaveProperty('error');
+  });
+
+  it('should not detect Laravel from artisan without laravel/framework', async () => {
+    const result = await detectProjectError({
+      '/project/composer.json': composerJson({ php: '^8.3' }),
+      '/project/artisan': '#!/usr/bin/env php',
+    });
+
+    expect(result).toHaveProperty('error');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/laravel.test.ts
+++ b/packages/network-config/src/detection/frameworks/laravel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { composerJson, detectProject, detectProjectError } from './test-utils';
+import { composerJson, detectProject, detectProjectError, packageJson } from './test-utils';
 
 const lockfileCases: Array<{ name: string; lockfile: Record<string, string> }> = [
   { name: 'no lockfile', lockfile: {} },
@@ -26,6 +26,8 @@ describe('Laravel framework detection', () => {
       '/project/composer.json': composerJson({ php: '^8.3', 'laravel/framework': '^11.0' }),
       '/project/artisan': '#!/usr/bin/env php',
       '/project/composer.lock': '',
+      '/project/package.json': packageJson({ vite: '^7.0.0' }),
+      '/project/bun.lockb': '',
     });
 
     expect(result.framework).toMatchObject({ slug: 'laravel', name: 'Laravel' });

--- a/packages/network-config/src/detection/frameworks/nestjs.test.ts
+++ b/packages/network-config/src/detection/frameworks/nestjs.test.ts
@@ -111,8 +111,30 @@ describe('NestJS framework detection', () => {
     expect(result.config.routes[0].destination).toBe('dist/main.js');
   });
 
-  it.each(['/tmp/build', '../build', 'nested/../build', ''])(
-    'should ignore unsafe NestJS output path %s and keep the default output path',
+  it.each([
+    '/tmp/build',
+    '../build',
+    'nested/../build',
+    '..\\build',
+    'nested\\..\\build',
+    'C:\\build',
+    '\\\\server\\share',
+    'dist:build',
+    '.',
+  ])('should ignore unsafe NestJS output path %s and keep the default output path', async (outputPath) => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/nest-cli.json': JSON.stringify({
+        compilerOptions: { outputPath },
+      }),
+    });
+
+    expect(result.config.entrypoints[0].path).toBe('dist/main.js');
+    expect(result.config.routes[0].destination).toBe('dist/main.js');
+  });
+
+  it.each(['', './', '.\\'])(
+    'should ignore empty-equivalent NestJS output path %s and keep the default output path',
     async (outputPath) => {
       const result = await detectProject({
         '/project/package.json': packageJson(dependencies),

--- a/packages/network-config/src/detection/frameworks/nestjs.test.ts
+++ b/packages/network-config/src/detection/frameworks/nestjs.test.ts
@@ -1,0 +1,128 @@
+import { Effect, Layer } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { makeTestFs, TestPathLayer } from '../../test-utils';
+import { detectFramework } from '../detect-framework';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { '@nestjs/core': '^10.0.0' };
+
+describe('NestJS framework detection', () => {
+  expectNodePackageManagerVariants('NestJS', dependencies, 'nest build');
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect NestJS from package.json', async () => {
+    const fs = makeTestFs({
+      '/project/package.json': JSON.stringify({
+        dependencies: { ...dependencies, express: '^4.0.0' },
+      }),
+    });
+
+    const result = await Effect.runPromise(
+      detectFramework('/project').pipe(Effect.provide(Layer.merge(fs, TestPathLayer)))
+    );
+
+    // NestJS has higher priority than Express.
+    expect(result.framework.slug).toBe('nestjs');
+    expect(result.config.entrypoints[0].path).toBe('dist/main.js');
+    expect(result.config.entrypoints[0].package).toBeUndefined();
+  });
+
+  it('should derive NestJS output path from nest-cli.json', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/nest-cli.json': JSON.stringify({
+        compilerOptions: { outputPath: 'build' },
+      }),
+    });
+
+    expect(result.framework.slug).toBe('nestjs');
+    expect(result.config.entrypoints[0].path).toBe('build/main.js');
+    expect(result.config.routes[0].destination).toBe('build/main.js');
+    expect(result.config.entrypoints[0].package).toBeUndefined();
+  });
+
+  it('should normalize dot-prefixed and trailing-slash NestJS output paths', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/nest-cli.json': JSON.stringify({
+        compilerOptions: { outputPath: './build/' },
+      }),
+    });
+
+    expect(result.config.entrypoints[0].path).toBe('build/main.js');
+    expect(result.config.routes[0].destination).toBe('build/main.js');
+  });
+
+  it('should derive NestJS output path from the default project in nest-cli.json', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/nest-cli.json': JSON.stringify({
+        defaultProject: 'api',
+        projects: {
+          worker: { compilerOptions: { outputPath: 'dist/worker' } },
+          api: { compilerOptions: { outputPath: 'dist/api' } },
+        },
+      }),
+    });
+
+    expect(result.config.entrypoints[0].path).toBe('dist/api/main.js');
+    expect(result.config.routes[0].destination).toBe('dist/api/main.js');
+  });
+
+  it('should fall back to the first NestJS project output path when no default project is configured', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/nest-cli.json': JSON.stringify({
+        projects: {
+          api: { compilerOptions: { outputPath: 'dist/api' } },
+          worker: { compilerOptions: { outputPath: 'dist/worker' } },
+        },
+      }),
+    });
+
+    expect(result.config.entrypoints[0].path).toBe('dist/api/main.js');
+    expect(result.config.routes[0].destination).toBe('dist/api/main.js');
+  });
+
+  it('should ignore malformed NestJS CLI config and keep the default output path', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/nest-cli.json': '{not-json',
+    });
+
+    expect(result.config.entrypoints[0].path).toBe('dist/main.js');
+    expect(result.config.routes[0].destination).toBe('dist/main.js');
+  });
+
+  it('should ignore non-string NestJS output paths and keep the default output path', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/nest-cli.json': JSON.stringify({
+        compilerOptions: { outputPath: 42 },
+      }),
+    });
+
+    expect(result.config.entrypoints[0].path).toBe('dist/main.js');
+    expect(result.config.routes[0].destination).toBe('dist/main.js');
+  });
+
+  it.each(['/tmp/build', '../build', 'nested/../build', ''])(
+    'should ignore unsafe NestJS output path %s and keep the default output path',
+    async (outputPath) => {
+      const result = await detectProject({
+        '/project/package.json': packageJson(dependencies),
+        '/project/nest-cli.json': JSON.stringify({
+          compilerOptions: { outputPath },
+        }),
+      });
+
+      expect(result.config.entrypoints[0].path).toBe('dist/main.js');
+      expect(result.config.routes[0].destination).toBe('dist/main.js');
+    }
+  );
+});

--- a/packages/network-config/src/detection/frameworks/nestjs.ts
+++ b/packages/network-config/src/detection/frameworks/nestjs.ts
@@ -1,4 +1,72 @@
-import type { FrameworkDefinition } from '../types';
+import { FileSystem } from '@effect/platform';
+import { Effect } from 'effect';
+import type { FrameworkDefaultConfig, FrameworkDefinition } from '../types';
+
+interface NestCliJson {
+  compilerOptions?: {
+    outputPath?: unknown;
+  };
+  defaultProject?: unknown;
+  projects?: Record<
+    string,
+    {
+      compilerOptions?: {
+        outputPath?: unknown;
+      };
+    }
+  >;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const parseNestCliJson = (content: string): NestCliJson | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!isRecord(parsed)) return undefined;
+    return parsed as NestCliJson;
+  } catch {
+    return undefined;
+  }
+};
+
+const getProjectOutputPath = (config: NestCliJson): string | undefined => {
+  if (typeof config.compilerOptions?.outputPath === 'string') {
+    return config.compilerOptions.outputPath;
+  }
+
+  if (typeof config.defaultProject === 'string') {
+    const outputPath = config.projects?.[config.defaultProject]?.compilerOptions?.outputPath;
+    if (typeof outputPath === 'string') return outputPath;
+  }
+
+  const firstProject = Object.values(config.projects ?? {})[0];
+  const outputPath = firstProject?.compilerOptions?.outputPath;
+  return typeof outputPath === 'string' ? outputPath : undefined;
+};
+
+const normalizeOutputPath = (outputPath: string): string | undefined => {
+  const normalized = outputPath.replace(/^\.\//, '').replace(/\/$/, '');
+  if (!normalized || normalized.startsWith('/') || normalized.split('/').some((segment) => segment === '..')) {
+    return undefined;
+  }
+  return normalized;
+};
+
+const createNestConfig = (outputPath: string): FrameworkDefaultConfig => {
+  const outputDirectory = normalizeOutputPath(outputPath) ?? 'dist';
+  const entrypoint = `${outputDirectory}/main.js`;
+
+  return {
+    runtime: 'node-22',
+    memory: 256,
+    maxDuration: 30,
+    streaming: true,
+    commands: ['nest build'],
+    entrypoint,
+    routes: [{ source: '/*', destination: entrypoint }],
+    environmentVariables: { NODE_ENV: 'production' },
+  };
+};
 
 export const nestjs: FrameworkDefinition = {
   slug: 'nestjs',
@@ -6,14 +74,19 @@ export const nestjs: FrameworkDefinition = {
   language: 'node',
   detectors: [{ matchPackage: '@nestjs/core' }],
   priority: 90,
-  getDefaultConfig: () => ({
-    runtime: 'node-22',
-    memory: 256,
-    maxDuration: 30,
-    streaming: true,
-    commands: ['nest build'],
-    entrypoint: 'dist/main.js',
-    routes: [{ source: '/*', destination: 'dist/main.js' }],
-    environmentVariables: { NODE_ENV: 'production' },
-  }),
+  getDefaultConfig: () => createNestConfig('dist'),
+  refineDefaultConfig: (defaults, projectFolder) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const content = yield* fs
+        .readFileString(`${projectFolder}/nest-cli.json`)
+        .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+
+      if (!content) return defaults;
+
+      const nestConfig = parseNestCliJson(content);
+      const outputPath = nestConfig ? getProjectOutputPath(nestConfig) : undefined;
+
+      return outputPath ? createNestConfig(outputPath) : defaults;
+    }),
 };

--- a/packages/network-config/src/detection/frameworks/nestjs.ts
+++ b/packages/network-config/src/detection/frameworks/nestjs.ts
@@ -45,8 +45,15 @@ const getProjectOutputPath = (config: NestCliJson): string | undefined => {
 };
 
 const normalizeOutputPath = (outputPath: string): string | undefined => {
-  const normalized = outputPath.replace(/^\.\//, '').replace(/\/$/, '');
-  if (!normalized || normalized.startsWith('/') || normalized.split('/').some((segment) => segment === '..')) {
+  const normalized = outputPath.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  if (
+    !normalized ||
+    normalized === '.' ||
+    normalized.startsWith('/') ||
+    /^[A-Za-z]:/.test(normalized) ||
+    normalized.includes(':') ||
+    normalized.split('/').some((segment) => segment === '..')
+  ) {
     return undefined;
   }
   return normalized;

--- a/packages/network-config/src/detection/frameworks/nextjs.test.ts
+++ b/packages/network-config/src/detection/frameworks/nextjs.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { next: '^16.0.0', react: '^19.0.0' };
+
+describe('Next.js framework detection', () => {
+  expectNodePackageManagerVariants('Next.js', dependencies, 'next build');
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Next.js and generate standalone server config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'nextjs', name: 'Next.js' });
+    expect(result.config.commands).toEqual(['npm install', 'next build']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: '.next/standalone/server.js',
+        runtime: 'node-22',
+        memory: 256,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([
+      expect.objectContaining({ path: '/*', destination: '.next/standalone/server.js' }),
+    ]);
+    expect(result.config.assets).toMatchObject({
+      prefixToStrip: '.next/static/',
+      dynamicRoutes: true,
+      populateCache: true,
+    });
+    expect(result.config.environmentVariables).toEqual({ NODE_ENV: 'production' });
+  });
+
+  it('should prefer Next.js over lower-priority Vite', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson({ ...dependencies, vite: '^7.0.0' }),
+    });
+
+    expect(result.framework.slug).toBe('nextjs');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/nuxt.test.ts
+++ b/packages/network-config/src/detection/frameworks/nuxt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { nuxt: '^4.0.0', vue: '^3.0.0' };
+
+describe('Nuxt framework detection', () => {
+  expectNodePackageManagerVariants('Nuxt', dependencies, 'nuxt build');
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Nuxt and generate Nitro node-server config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/pnpm-lock.yaml': '',
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'nuxt', name: 'Nuxt' });
+    expect(result.packageManager).toBe('pnpm');
+    expect(result.config.commands).toEqual(['pnpm install', 'nuxt build']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: '.output/server/index.mjs',
+        runtime: 'node-22',
+        memory: 256,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([
+      expect.objectContaining({ path: '/*', destination: '.output/server/index.mjs' }),
+    ]);
+    expect(result.config.assets).toMatchObject({ prefixToStrip: '.output/public/', populateCache: true });
+    expect(result.config.environmentVariables).toEqual({ NODE_ENV: 'production', NITRO_PRESET: 'node-server' });
+  });
+});

--- a/packages/network-config/src/detection/frameworks/remix.test.ts
+++ b/packages/network-config/src/detection/frameworks/remix.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { '@remix-run/dev': '^2.0.0', express: '^4.0.0' };
+
+describe('Remix framework detection', () => {
+  expectNodePackageManagerVariants('Remix', dependencies, 'remix build');
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Remix and generate server/client build config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'remix', name: 'Remix' });
+    expect(result.config.commands).toEqual(['npm install', 'remix build']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'build/server/index.js',
+        runtime: 'node-22',
+        memory: 256,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([
+      expect.objectContaining({ path: '/*', destination: 'build/server/index.js' }),
+    ]);
+    expect(result.config.assets).toMatchObject({ prefixToStrip: 'build/client/', populateCache: true });
+  });
+
+  it('should prefer Remix over Express', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+    });
+
+    expect(result.framework.slug).toBe('remix');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/sveltekit.test.ts
+++ b/packages/network-config/src/detection/frameworks/sveltekit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { '@sveltejs/kit': '^2.0.0', vite: '^7.0.0' };
+
+describe('SvelteKit framework detection', () => {
+  expectNodePackageManagerVariants('SvelteKit', dependencies, 'vite build');
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect SvelteKit and generate node adapter-style config', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/yarn.lock': '',
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'sveltekit', name: 'SvelteKit' });
+    expect(result.packageManager).toBe('yarn');
+    expect(result.config.commands).toEqual(['yarn install', 'vite build']);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'build/index.js',
+        runtime: 'node-22',
+        memory: 256,
+        maxDuration: 30,
+        streaming: true,
+      }),
+    ]);
+    expect(result.config.routes).toEqual([expect.objectContaining({ path: '/*', destination: 'build/index.js' })]);
+    expect(result.config.assets).toMatchObject({ prefixToStrip: 'build/client/', populateCache: true });
+  });
+
+  it('should prefer SvelteKit over Vite', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+    });
+
+    expect(result.framework.slug).toBe('sveltekit');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/symfony.test.ts
+++ b/packages/network-config/src/detection/frameworks/symfony.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { composerJson, detectProject, detectProjectError } from './test-utils';
+
+const lockfileCases: Array<{ name: string; lockfile: Record<string, string> }> = [
+  { name: 'no lockfile', lockfile: {} },
+  { name: 'composer.lock', lockfile: { '/project/composer.lock': '' } },
+  { name: 'package-lock.json', lockfile: { '/project/package-lock.json': '' } },
+  { name: 'pnpm-lock.yaml', lockfile: { '/project/pnpm-lock.yaml': '' } },
+  { name: 'bun.lockb', lockfile: { '/project/bun.lockb': '' } },
+];
+
+describe('Symfony framework detection', () => {
+  it.each(lockfileCases)(
+    'should use optimized composer install for Symfony projects with $name',
+    async ({ lockfile }) => {
+      const result = await detectProject({
+        '/project/composer.json': composerJson({ php: '^8.3', 'symfony/framework-bundle': '^7.0' }),
+        '/project/bin/console': '#!/usr/bin/env php',
+        ...lockfile,
+      });
+
+      expect(result.packageManager).toBe('composer');
+      expect(result.config.commands[0]).toBe('composer install --prefer-dist --optimize-autoloader --no-dev');
+    }
+  );
+
+  it('should detect Symfony and generate public PHP entrypoint config', async () => {
+    const result = await detectProject({
+      '/project/composer.json': composerJson({ php: '^8.3', 'symfony/framework-bundle': '^7.0' }),
+      '/project/bin/console': '#!/usr/bin/env php',
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'symfony', name: 'Symfony' });
+    expect(result.config.commands).toEqual([
+      'composer install --prefer-dist --optimize-autoloader --no-dev',
+      'bun install',
+      'bun run build',
+    ]);
+    expect(result.config.entrypoints).toEqual([
+      expect.objectContaining({
+        path: 'public/index.php',
+        runtime: 'php-84',
+        memory: 512,
+        maxDuration: 30,
+        streaming: false,
+        symlinks: { var: '/tmp' },
+      }),
+    ]);
+    expect(result.config.routes).toEqual([expect.objectContaining({ path: '/*', destination: 'public/index.php' })]);
+    expect(result.config.assets).toMatchObject({ prefixToStrip: 'public/', populateCache: true });
+    expect(result.config.excludeFiles).toEqual(['tests/*', '.ddev', 'var']);
+    expect(result.config.environmentVariables).toMatchObject({
+      APP_ENV: 'prod',
+      APP_DEBUG: 'false',
+      MESSENGER_TRANSPORT_DSN: 'doctrine://default?auto_setup=0',
+    });
+  });
+
+  it('should require bin/console in addition to symfony/framework-bundle', async () => {
+    const result = await detectProjectError({
+      '/project/composer.json': composerJson({ 'symfony/framework-bundle': '^7.0' }),
+    });
+
+    expect(result).toHaveProperty('error');
+  });
+
+  it('should not detect Symfony from bin/console without symfony/framework-bundle', async () => {
+    const result = await detectProjectError({
+      '/project/composer.json': composerJson({ php: '^8.3' }),
+      '/project/bin/console': '#!/usr/bin/env php',
+    });
+
+    expect(result).toHaveProperty('error');
+  });
+});

--- a/packages/network-config/src/detection/frameworks/symfony.test.ts
+++ b/packages/network-config/src/detection/frameworks/symfony.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { composerJson, detectProject, detectProjectError } from './test-utils';
+import { composerJson, detectProject, detectProjectError, packageJson } from './test-utils';
 
 const lockfileCases: Array<{ name: string; lockfile: Record<string, string> }> = [
   { name: 'no lockfile', lockfile: {} },
@@ -28,6 +28,8 @@ describe('Symfony framework detection', () => {
     const result = await detectProject({
       '/project/composer.json': composerJson({ php: '^8.3', 'symfony/framework-bundle': '^7.0' }),
       '/project/bin/console': '#!/usr/bin/env php',
+      '/project/package.json': packageJson({ vite: '^7.0.0' }),
+      '/project/bun.lockb': '',
     });
 
     expect(result.framework).toMatchObject({ slug: 'symfony', name: 'Symfony' });

--- a/packages/network-config/src/detection/frameworks/test-utils.ts
+++ b/packages/network-config/src/detection/frameworks/test-utils.ts
@@ -1,0 +1,79 @@
+import { Effect, Layer } from 'effect';
+import { expect, it } from 'vitest';
+import { makeTestFs, TestPathLayer } from '../../test-utils';
+import { detectFramework } from '../detect-framework';
+import type { PackageManager } from '../types';
+
+export const packageJson = (dependencies: Record<string, string>) => JSON.stringify({ dependencies });
+
+export const composerJson = (requires: Record<string, string>) => JSON.stringify({ require: requires });
+
+export const nodePackageManagerCases: Array<{
+  name: string;
+  packageManager: Exclude<PackageManager, 'composer'>;
+  lockfile: Record<string, string>;
+  installCommand: string;
+}> = [
+  { name: 'npm', packageManager: 'npm', lockfile: { '/project/package-lock.json': '' }, installCommand: 'npm install' },
+  { name: 'pnpm', packageManager: 'pnpm', lockfile: { '/project/pnpm-lock.yaml': '' }, installCommand: 'pnpm install' },
+  { name: 'yarn', packageManager: 'yarn', lockfile: { '/project/yarn.lock': '' }, installCommand: 'yarn install' },
+  { name: 'bun.lockb', packageManager: 'bun', lockfile: { '/project/bun.lockb': '' }, installCommand: 'bun install' },
+  { name: 'bun.lock', packageManager: 'bun', lockfile: { '/project/bun.lock': '' }, installCommand: 'bun install' },
+];
+
+export const expectNodePackageManagerVariants = (
+  frameworkName: string,
+  dependencies: Record<string, string>,
+  buildCommand?: string
+) => {
+  it.each(nodePackageManagerCases)(
+    `should use $name for ${frameworkName} installs`,
+    async ({ packageManager, lockfile, installCommand }) => {
+      const result = await detectProject({
+        '/project/package.json': packageJson(dependencies),
+        ...lockfile,
+      });
+
+      expect(result.packageManager).toBe(packageManager);
+      expect(result.config.commands).toEqual(buildCommand ? [installCommand, buildCommand] : [installCommand]);
+    }
+  );
+};
+
+export const expectNodePackageManagerPriority = (dependencies: Record<string, string>) => {
+  it('should prefer Bun over pnpm, yarn, and npm lockfiles', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/bun.lockb': '',
+      '/project/pnpm-lock.yaml': '',
+      '/project/yarn.lock': '',
+      '/project/package-lock.json': '',
+    });
+
+    expect(result.packageManager).toBe('bun');
+    expect(result.config.commands[0]).toBe('bun install');
+  });
+
+  it('should prefer pnpm over yarn and npm lockfiles', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+      '/project/pnpm-lock.yaml': '',
+      '/project/yarn.lock': '',
+      '/project/package-lock.json': '',
+    });
+
+    expect(result.packageManager).toBe('pnpm');
+    expect(result.config.commands[0]).toBe('pnpm install');
+  });
+};
+
+export const detectProject = (files: Record<string, string>) =>
+  Effect.runPromise(detectFramework('/project').pipe(Effect.provide(Layer.merge(makeTestFs(files), TestPathLayer))));
+
+export const detectProjectError = (files: Record<string, string>) =>
+  Effect.runPromise(
+    detectFramework('/project').pipe(
+      Effect.catchTag('FrameworkNotDetectedError', (error) => Effect.succeed({ error })),
+      Effect.provide(Layer.merge(makeTestFs(files), TestPathLayer))
+    )
+  );

--- a/packages/network-config/src/detection/frameworks/vite.test.ts
+++ b/packages/network-config/src/detection/frameworks/vite.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectProject,
+  expectNodePackageManagerPriority,
+  expectNodePackageManagerVariants,
+  packageJson,
+} from './test-utils';
+
+const dependencies = { vite: '^7.0.0', react: '^19.0.0' };
+
+describe('Vite framework detection', () => {
+  expectNodePackageManagerVariants('Vite', dependencies, 'vite build');
+  expectNodePackageManagerPriority(dependencies);
+
+  it('should detect Vite and generate static asset config without server entrypoints', async () => {
+    const result = await detectProject({
+      '/project/package.json': packageJson(dependencies),
+    });
+
+    expect(result.framework).toMatchObject({ slug: 'vite', name: 'Vite' });
+    expect(result.config.commands).toEqual(['npm install', 'vite build']);
+    expect(result.config.entrypoints).toEqual([]);
+    expect(result.config.routes).toEqual([]);
+    expect(result.config.assets).toMatchObject({ prefixToStrip: 'dist/', populateCache: true });
+    expect(result.config.environmentVariables).toEqual({ NODE_ENV: 'production' });
+  });
+});

--- a/packages/network-config/src/detection/generate-config.test.ts
+++ b/packages/network-config/src/detection/generate-config.test.ts
@@ -137,6 +137,26 @@ describe('generateConfig', () => {
     expect(result.excludeFiles).toEqual(['tests/', 'storage/', '.ddev', 'node_modules/']);
   });
 
+  it('should copy framework package defaults onto generated entrypoints', async () => {
+    const frameworkWithPackageDefaults: FrameworkDefinition = {
+      ...mockFramework,
+      getDefaultConfig: () => ({
+        ...mockFramework.getDefaultConfig('npm'),
+        package: {
+          includeFiles: ['dist/**', 'package.json', 'node_modules/**'],
+          excludeFiles: ['**/*.map'],
+        },
+      }),
+    };
+
+    const result = await Effect.runPromise(generateConfig(frameworkWithPackageDefaults, 'npm'));
+
+    expect(result.entrypoints[0].package).toEqual({
+      includeFiles: ['dist/**', 'package.json', 'node_modules/**'],
+      excludeFiles: ['**/*.map'],
+    });
+  });
+
   it('should not set excludeFiles when not provided', async () => {
     const result = await Effect.runPromise(generateConfig(mockFramework, 'npm'));
     expect(result.excludeFiles).toBeUndefined();

--- a/packages/network-config/src/detection/generate-config.ts
+++ b/packages/network-config/src/detection/generate-config.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect';
 import type { NormalizedConfig } from '../normalized-config';
 import { AVAILABLE_REGIONS } from '../regions';
-import type { FrameworkDefinition, PackageManager } from './types';
+import type { FrameworkDefaultConfig, FrameworkDefinition, PackageManager } from './types';
 
 /**
  * Returns the install command for the given package manager.
@@ -32,9 +32,10 @@ const getInstallCommand = (pm: PackageManager): string => {
  */
 export const generateConfig = Effect.fn('generateConfig')(function* (
   framework: FrameworkDefinition,
-  packageManager: PackageManager
+  packageManager: PackageManager,
+  refinedDefaults?: FrameworkDefaultConfig
 ) {
-  const defaults = framework.getDefaultConfig(packageManager);
+  const defaults = refinedDefaults ?? framework.getDefaultConfig(packageManager);
 
   const installCmd = defaults.installCommand ?? getInstallCommand(packageManager);
   const commands = [installCmd, ...defaults.commands];
@@ -54,6 +55,7 @@ export const generateConfig = Effect.fn('generateConfig')(function* (
           maxDuration: defaults.maxDuration,
           streaming: defaults.streaming,
           symlinks: defaults.symlinks,
+          package: defaults.package,
         },
       ]
     : [];

--- a/packages/network-config/src/detection/types.ts
+++ b/packages/network-config/src/detection/types.ts
@@ -1,4 +1,5 @@
-import { Schema } from 'effect';
+import type { FileSystem } from '@effect/platform';
+import { Effect, Schema } from 'effect';
 import type { NormalizedConfig } from '../normalized-config';
 import type { Runtime } from '../runtime';
 
@@ -56,6 +57,11 @@ export interface FrameworkDefinition {
   priority: number;
   /** Generates deployment defaults for this framework */
   getDefaultConfig: (packageManager: PackageManager) => FrameworkDefaultConfig;
+  /** Refines defaults with project files after a framework match, e.g. framework CLI config. */
+  refineDefaultConfig?: (
+    defaults: FrameworkDefaultConfig,
+    projectFolder: string
+  ) => Effect.Effect<FrameworkDefaultConfig, never, FileSystem.FileSystem>;
 }
 
 export interface FrameworkDefaultConfig {
@@ -74,6 +80,12 @@ export interface FrameworkDefaultConfig {
   environmentVariables: Record<string, string>;
   symlinks?: Record<string, string>;
   excludeFiles?: string[];
+  package?: {
+    rootOverwrite?: string;
+    filePathMap?: Record<string, string>;
+    includeFiles?: string[];
+    excludeFiles?: string[];
+  };
 }
 
 export interface DetectionResult {

--- a/packages/network-config/src/normalized-config.ts
+++ b/packages/network-config/src/normalized-config.ts
@@ -159,6 +159,8 @@ export interface NormalizedConfigEntrypoint {
   package?: {
     rootOverwrite?: string;
     filePathMap?: FilePathMap;
+    includeFiles?: string[];
+    excludeFiles?: string[];
   };
 }
 

--- a/packages/network-config/src/services/v4-config-parser.test.ts
+++ b/packages/network-config/src/services/v4-config-parser.test.ts
@@ -4,6 +4,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { Effect, Layer } from 'effect';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parse as parseYaml } from 'yaml';
@@ -16,6 +17,18 @@ import { getFunctionSettings, V4ConfigParser } from './v4-config-parser';
 const loadExample = (): Record<string, unknown> => {
   const content = fs.readFileSync(path.join(__dirname, '../v4/example.yaml'), 'utf8');
   return parseYaml(content) as Record<string, unknown>;
+};
+
+const withTempFunctionProject = async <T>(run: (projectFolder: string) => Promise<T>): Promise<T> => {
+  const projectFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'network-config-v4-'));
+  try {
+    fs.mkdirSync(path.join(projectFolder, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(projectFolder, 'dist/main.js'), 'exports.handler = () => {}');
+    fs.writeFileSync(path.join(projectFolder, 'dist/health.js'), 'exports.handler = () => {}');
+    return await run(projectFolder);
+  } finally {
+    fs.rmSync(projectFolder, { recursive: true, force: true });
+  }
 };
 
 describe('V4ConfigParser', () => {
@@ -82,6 +95,175 @@ describe('V4ConfigParser', () => {
 
     expect(getFunctionSettings('app/test.ts', config as ConfigV4)).toBeUndefined();
     expect(getFunctionSettings('test/index.ts', config as ConfigV4)).toBeUndefined();
+  });
+
+  it('should preserve function includeFiles and excludeFiles as package rules', async () => {
+    await withTempFunctionProject(async (projectFolder) => {
+      const config: ConfigV4 = {
+        version: 4,
+        functions: {
+          'dist/main.js': {
+            runtime: 'node-22',
+            includeFiles: ['maxmind/**'],
+            excludeFiles: ['**/*.map'],
+          },
+        },
+      };
+
+      const result = await Effect.runPromise(
+        V4ConfigParser.parse(config, projectFolder).pipe(
+          Effect.provide(V4ConfigParser.Default),
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect(result.entrypoints[0].package).toEqual({
+        includeFiles: ['maxmind/**'],
+        excludeFiles: ['**/*.map'],
+      });
+    });
+  });
+
+  it('should normalize scalar includeFiles and excludeFiles into package rule arrays', async () => {
+    await withTempFunctionProject(async (projectFolder) => {
+      const config: ConfigV4 = {
+        version: 4,
+        functions: {
+          'dist/main.js': {
+            runtime: 'node-22',
+            includeFiles: 'maxmind/**',
+            excludeFiles: '**/*.map',
+          },
+        },
+      };
+
+      const result = await Effect.runPromise(
+        V4ConfigParser.parse(config, projectFolder).pipe(
+          Effect.provide(V4ConfigParser.Default),
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect(result.entrypoints[0].package).toEqual({
+        includeFiles: ['maxmind/**'],
+        excludeFiles: ['**/*.map'],
+      });
+    });
+  });
+
+  it('should preserve package rules when only includeFiles is configured', async () => {
+    await withTempFunctionProject(async (projectFolder) => {
+      const config: ConfigV4 = {
+        version: 4,
+        functions: {
+          'dist/main.js': {
+            runtime: 'node-22',
+            includeFiles: ['maxmind/**'],
+          },
+        },
+      };
+
+      const result = await Effect.runPromise(
+        V4ConfigParser.parse(config, projectFolder).pipe(
+          Effect.provide(V4ConfigParser.Default),
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect(result.entrypoints[0].package).toEqual({
+        includeFiles: ['maxmind/**'],
+        excludeFiles: undefined,
+      });
+    });
+  });
+
+  it('should preserve package rules when only excludeFiles is configured', async () => {
+    await withTempFunctionProject(async (projectFolder) => {
+      const config: ConfigV4 = {
+        version: 4,
+        functions: {
+          'dist/main.js': {
+            runtime: 'node-22',
+            excludeFiles: ['**/*.map'],
+          },
+        },
+      };
+
+      const result = await Effect.runPromise(
+        V4ConfigParser.parse(config, projectFolder).pipe(
+          Effect.provide(V4ConfigParser.Default),
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect(result.entrypoints[0].package).toEqual({
+        includeFiles: undefined,
+        excludeFiles: ['**/*.map'],
+      });
+    });
+  });
+
+  it('should not create package metadata when includeFiles and excludeFiles are absent', async () => {
+    await withTempFunctionProject(async (projectFolder) => {
+      const config: ConfigV4 = {
+        version: 4,
+        functions: {
+          'dist/main.js': {
+            runtime: 'node-22',
+          },
+        },
+      };
+
+      const result = await Effect.runPromise(
+        V4ConfigParser.parse(config, projectFolder).pipe(
+          Effect.provide(V4ConfigParser.Default),
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      expect(result.entrypoints[0].package).toBeUndefined();
+    });
+  });
+
+  it('should merge package rules from broad function settings into matching concrete functions', async () => {
+    await withTempFunctionProject(async (projectFolder) => {
+      const config: ConfigV4 = {
+        version: 4,
+        functions: {
+          'dist/*.js': {
+            runtime: 'node-22',
+            includeFiles: ['shared/**'],
+            excludeFiles: ['**/*.map'],
+          },
+          'dist/main.js': {
+            memory: 512,
+            includeFiles: ['maxmind/**'],
+          },
+        },
+      };
+
+      const result = await Effect.runPromise(
+        V4ConfigParser.parse(config, projectFolder).pipe(
+          Effect.provide(V4ConfigParser.Default),
+          Effect.provide(NodeContext.layer)
+        )
+      );
+
+      const main = result.entrypoints.find((entrypoint) => entrypoint.path === 'dist/main.js');
+      const health = result.entrypoints.find((entrypoint) => entrypoint.path === 'dist/health.js');
+
+      expect(main).toMatchObject({
+        memory: 512,
+        package: {
+          includeFiles: ['maxmind/**'],
+          excludeFiles: ['**/*.map'],
+        },
+      });
+      expect(health?.package).toEqual({
+        includeFiles: ['shared/**'],
+        excludeFiles: ['**/*.map'],
+      });
+    });
   });
 
   it('should collect assets from nested directories', async () => {

--- a/packages/network-config/src/services/v4-config-parser.ts
+++ b/packages/network-config/src/services/v4-config-parser.ts
@@ -32,6 +32,11 @@ const DEFAULT_FUNCTION_SETTINGS: Required<Pick<ConfigV4FunctionSettings, 'memory
   includeFiles: undefined,
 };
 
+const toArray = (value: string | string[] | undefined): string[] | undefined => {
+  if (value == null) return undefined;
+  return Array.isArray(value) ? value : [value];
+};
+
 // -- Pure helpers (no Effect needed) ----------------------------------------------------------
 
 /**
@@ -147,6 +152,13 @@ const parseEntrypoints = Effect.fn('parseEntrypoints')(function* (config: Config
         symlinks: func.symlinks,
         streaming:
           settings!.runtime == null || settings!.runtime.startsWith('node-') || settings!.runtime.startsWith('bun-'),
+        package:
+          settings!.includeFiles != null || settings!.excludeFiles != null
+            ? {
+                includeFiles: toArray(settings!.includeFiles),
+                excludeFiles: toArray(settings!.excludeFiles),
+              }
+            : undefined,
       });
     }
   }


### PR DESCRIPTION
## Summary
- preserve function includeFiles/excludeFiles in normalized entrypoint package metadata
- refine NestJS defaults from nest-cli.json output paths
- add per-framework detection/config tests and Composer handling for PHP frameworks

## Tests
- pnpm format
- pnpm vitest run packages/network-config
- pnpm --filter @gigadrive/network-config typecheck
- pnpm --filter @gigadrive/network-config build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-entrypoint `includeFiles` and `excludeFiles` configuration for granular control over packaging.

* **Improvements**
  * Enhanced NestJS framework detection to read configuration from `nest-cli.json`.
  * Refined package manager detection with improved prioritization logic.
  * Expanded framework detection coverage with improved accuracy across multiple platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gigadrive/sdk/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->