### PR TITLE
Refactor Harmony Select to canonical shadcn variant

### DIFF
--- a/.changeset/harmony-canonical-select.md
+++ b/.changeset/harmony-canonical-select.md
@@ -1,0 +1,13 @@
+---
+'@gigadrive/harmony': major
+---
+
+Replace `Select` with the canonical shadcn implementation.
+
+**BREAKING:**
+
+- Removes the indicator `Context` and the `indicatorPosition` / `indicatorVisibility` / `indicator` props on `Select`, along with the `SelectIndicator` export. Compose a custom item indicator manually if you relied on these.
+- Trigger `size` is now `sm` | `default` (previously `sm` | `md` | `lg`); the default is `default`.
+- `SelectContent` now defaults to `item-aligned` positioning (previously `popper`). Pass `position="popper"` to restore the old behaviour.
+
+The selected-item check indicator now renders on the right, and the component adopts shadcn's current `data-slot` styling and dynamic max-height.

--- a/.changeset/harmony-canonical-select.md
+++ b/.changeset/harmony-canonical-select.md
@@ -11,3 +11,5 @@ Replace `Select` with the canonical shadcn implementation.
 - `SelectContent` now defaults to `item-aligned` positioning (previously `popper`). Pass `position="popper"` to restore the old behaviour.
 
 The selected-item check indicator now renders on the right, and the component adopts shadcn's current `data-slot` styling and dynamic max-height.
+
+**Fix:** normalize Tailwind v4-only utilities to their Tailwind v3 equivalents across the library (harmony is pinned to Tailwind v3). These classes previously emitted no CSS, most visibly leaving a stray native focus outline — a white ring in dark mode / black in light mode — on hovered/highlighted items. Affected components: `Select`, `Popover`, `Command`, `Calendar`, `ContextMenu`, and `ButtonGroup` (`outline-hidden`→`outline-none`, `shadow-xs`→`shadow-sm`, `has-focus:`→`has-[:focus]:`, `**:`→`[&_…]`, and `foo-(--bar)`→`foo-[var(--bar)]`).

--- a/.changeset/harmony-canonical-select.md
+++ b/.changeset/harmony-canonical-select.md
@@ -6,7 +6,7 @@ Replace `Select` with the canonical shadcn implementation.
 
 **BREAKING:**
 
-- Removes the indicator `Context` and the `indicatorPosition` / `indicatorVisibility` / `indicator` props on `Select`, along with the `SelectIndicator` export. Compose a custom item indicator manually if you relied on these.
+- Removes the indicator `Context` and the `indicatorPosition` / `indicatorVisibility` / `indicator` props on `Select`, along with the `SelectIndicator` export. `SelectItem` now always renders the built-in right-aligned checkmark (`SelectPrimitive.ItemIndicator`); to customise the indicator, fork or wrap `SelectItem` and override that markup/styles.
 - Trigger `size` is now `sm` | `default` (previously `sm` | `md` | `lg`); the default is `default`.
 - `SelectContent` now defaults to `item-aligned` positioning (previously `popper`). Pass `position="popper"` to restore the old behaviour.
 

--- a/packages/harmony/AGENTS.md
+++ b/packages/harmony/AGENTS.md
@@ -145,6 +145,34 @@ Path aliases: `@/*` maps to `src/*`, `stories/*` maps to `stories/*`.
 - Animations: `tailwindcss-animate` plugin + custom keyframes in tailwind config.
 - Font: Resist Sans Text (extends default sans stack).
 
+### Tailwind version: we are on v3 (NOT v4)
+
+harmony runs **Tailwind CSS v3** (`tailwindcss@^3.4`, JS config `tailwind.config.ts`,
+`@tailwind base/components/utilities` directives). Do **not** use Tailwind v4-only
+utilities — v3 silently drops unknown classes (they emit no CSS), so a v4 class looks
+fine in the source but does nothing at runtime. The most common symptom is a stray
+native `:focus-visible` outline (a white ring in dark mode / black in light mode)
+where `outline-hidden` was expected.
+
+shadcn/ui components are now authored for v4, so when porting one, normalize its
+classes to v3 first. Known v4-only → v3 replacements (verified against `tailwindcss@3.4`):
+
+| v4 (no-op in v3)                                                    | v3 equivalent                                        |
+| ------------------------------------------------------------------- | ---------------------------------------------------- |
+| `outline-hidden`                                                    | `outline-none`                                       |
+| `shadow-xs`, `shadow-2xs`                                           | `shadow-sm`                                          |
+| `has-focus:` (bare pseudo shorthand)                                | `has-[:focus]:` (also `group-has-[:focus]:`)         |
+| `foo-(--bar)` CSS-var shorthand                                     | `foo-[var(--bar)]`                                   |
+| `**:` (deep-descendant variant)                                     | `[&_…]`                                              |
+| `field-sizing-*`, `text-shadow-*`, `inset-shadow-*`, `inset-ring-*` | no v3 equivalent — use an arbitrary property or drop |
+
+Note: `size-*`, `*:` (direct-child variant), `has-[:focus]`, and `foo-[--bar]`/`foo-[var(--bar)]`
+are all valid in v3.4 — leave them. To check whether a class is valid, compile a probe
+file with `packages/harmony/node_modules/.bin/tailwindcss`: if the class is absent from
+the output CSS, it's a v4-only no-op. (The v4 packages in `package.json` —
+`@tailwindcss/postcss`, `@tailwindcss/vite` — are currently unused; a real v4 migration
+is a separate, deliberate effort.)
+
 ### Exports
 
 - Barrel `src/index.ts` re-exports from `./lib`, `./hooks`, and key components.

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "rslib build",
     "clean": "rm -rf dist",
-    "storybook": "storybook dev -p 6006 --no-open",
+    "storybook": "storybook dev -p 6006 --host 0.0.0.0 --no-open",
     "storybook:build": "storybook build",
     "storybook:build-docs": "storybook build --docs",
     "typecheck": "tsc --noEmit -p tsconfig.check.json"

--- a/packages/harmony/src/components/ui/button-group.tsx
+++ b/packages/harmony/src/components/ui/button-group.tsx
@@ -49,7 +49,7 @@ function ButtonGroupText({
   return (
     <Comp
       className={cn(
-        "bg-muted shadow-xs flex items-center gap-2 rounded-md border px-4 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+        "bg-muted shadow-sm flex items-center gap-2 rounded-md border px-4 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
         className
       )}
       {...props}

--- a/packages/harmony/src/components/ui/calendar.tsx
+++ b/packages/harmony/src/components/ui/calendar.tsx
@@ -24,8 +24,8 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn(
         'bg-background group/calendar p-3 [--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
-        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
-        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        String.raw`rtl:[&_.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:[&_.rdp-button\_previous>svg]:rotate-180`,
         className
       )}
       captionLayout={captionLayout}
@@ -57,7 +57,7 @@ function Calendar({
           defaultClassNames.dropdowns
         ),
         dropdown_root: cn(
-          'has-focus:border-ring border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] relative rounded-md border',
+          'has-[:focus]:border-ring border-input shadow-sm has-[:focus]:ring-ring/50 has-[:focus]:ring-[3px] relative rounded-md border',
           defaultClassNames.dropdown_root
         ),
         dropdown: cn('bg-popover absolute inset-0 opacity-0', defaultClassNames.dropdown),

--- a/packages/harmony/src/components/ui/command.tsx
+++ b/packages/harmony/src/components/ui/command.tsx
@@ -40,7 +40,7 @@ function CommandInput({ className, ...props }: React.ComponentProps<typeof Comma
       <Search className="me-2 h-4 w-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         className={cn(
-          'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden text-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none text-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         {...props}
@@ -91,7 +91,7 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Comman
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        'relative flex text-foreground cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        'relative flex text-foreground cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
         className
       )}
       {...props}

--- a/packages/harmony/src/components/ui/context-menu.tsx
+++ b/packages/harmony/src/components/ui/context-menu.tsx
@@ -57,7 +57,7 @@ function ContextMenuSubContent({ className, ...props }: React.ComponentProps<typ
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-[var(--radix-context-menu-content-transform-origin)] overflow-hidden rounded-md border p-1 shadow-lg',
         className
       )}
       {...props}
@@ -71,7 +71,7 @@ function ContextMenuContent({ className, ...props }: React.ComponentProps<typeof
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[var(--radix-context-menu-content-available-height)] min-w-[8rem] origin-[var(--radix-context-menu-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
           className
         )}
         {...props}

--- a/packages/harmony/src/components/ui/context-menu.tsx
+++ b/packages/harmony/src/components/ui/context-menu.tsx
@@ -95,7 +95,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive [&[data-variant=destructive]_svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/packages/harmony/src/components/ui/popover.tsx
+++ b/packages/harmony/src/components/ui/popover.tsx
@@ -25,7 +25,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md shadow-black/5 outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'z-50 w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md shadow-black/5 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className
         )}
         {...props}

--- a/packages/harmony/src/components/ui/select.tsx
+++ b/packages/harmony/src/components/ui/select.tsx
@@ -30,7 +30,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-sm transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className
@@ -95,7 +95,7 @@ function SelectItem({ className, children, ...props }: React.ComponentProps<type
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/packages/harmony/src/components/ui/select.tsx
+++ b/packages/harmony/src/components/ui/select.tsx
@@ -1,36 +1,13 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { cva, VariantProps } from 'class-variance-authority';
-import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import { Select as SelectPrimitive } from 'radix-ui';
 import * as React from 'react';
-import { isValidElement, ReactNode } from 'react';
 
-// Create a Context for `indicatorPosition` and `indicator` control
-const SelectContext = React.createContext<{
-  indicatorPosition: 'left' | 'right';
-  indicatorVisibility: boolean;
-  indicator: ReactNode;
-}>({ indicatorPosition: 'left', indicator: null, indicatorVisibility: true });
-
-// Root Component
-const Select = ({
-  indicatorPosition = 'left',
-  indicatorVisibility = true,
-  indicator,
-  ...props
-}: {
-  indicatorPosition?: 'left' | 'right';
-  indicatorVisibility?: boolean;
-  indicator?: ReactNode;
-} & React.ComponentProps<typeof SelectPrimitive.Root>) => {
-  return (
-    <SelectContext.Provider value={{ indicatorPosition, indicatorVisibility, indicator }}>
-      <SelectPrimitive.Root {...props} />
-    </SelectContext.Provider>
-  );
-};
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
 
 function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
@@ -40,78 +17,37 @@ function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.V
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
-// Define size variants for SelectTrigger
-const selectTriggerVariants = cva(
-  `
-    flex bg-background w-full items-center justify-between outline-none border border-input shadow-xs shadow-black/5 transition-shadow
-    text-foreground data-placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px]
-    focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1
-    aria-invalid:border-destructive/60 aria-invalid:ring-destructive/10 dark:aria-invalid:border-destructive dark:aria-invalid:ring-destructive/20
-    [[data-invalid=true]_&]:border-destructive/60 [[data-invalid=true]_&]:ring-destructive/10  dark:[[data-invalid=true]_&]:border-destructive dark:[[data-invalid=true]_&]:ring-destructive/20
-  `,
-  {
-    variants: {
-      size: {
-        sm: 'h-7 px-2.5 text-xs gap-1 rounded-md',
-        md: 'h-8.5 px-3 text-[0.8125rem] leading-(--text-sm--line-height) gap-1 rounded-md',
-        lg: 'h-10 px-4 text-sm gap-1.5 rounded-md',
-      },
-    },
-    defaultVariants: {
-      size: 'md',
-    },
-  }
-);
-
-export interface SelectTriggerProps
-  extends React.ComponentProps<typeof SelectPrimitive.Trigger>, VariantProps<typeof selectTriggerVariants> {}
-
-function SelectTrigger({ className, children, size, ...props }: SelectTriggerProps) {
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
-      className={cn(selectTriggerVariants({ size }), className)}
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
       {...props}
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDown className="h-4 w-4 opacity-60 -me-0.5" />
+        <ChevronDownIcon className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  );
-}
-
-function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
-  return (
-    <SelectPrimitive.ScrollUpButton
-      data-slot="select-scroll-up-button"
-      className={cn('flex cursor-default items-center justify-center py-1', className)}
-      {...props}
-    >
-      <ChevronUp className="h-4 w-4" />
-    </SelectPrimitive.ScrollUpButton>
-  );
-}
-
-function SelectScrollDownButton({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
-  return (
-    <SelectPrimitive.ScrollDownButton
-      data-slot="select-scroll-down-button"
-      className={cn('flex cursor-default items-center justify-center py-1', className)}
-      {...props}
-    >
-      <ChevronDown className="h-4 w-4" />
-    </SelectPrimitive.ScrollDownButton>
   );
 }
 
 function SelectContent({
   className,
   children,
-  position = 'popper',
+  position = 'item-aligned',
+  align = 'center',
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -119,20 +55,21 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover shadow-md shadow-black/5 text-secondary-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
-            'data-[side=bottom]:translate-y-1.5 data-[side=left]:-translate-x-1.5 data-[side=right]:translate-x-1.5 data-[side=top]:-translate-y-1.5',
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className
         )}
         position={position}
+        align={align}
         {...props}
       >
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
-            'p-1.5',
+            'p-1',
             position === 'popper' &&
-              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
           )}
         >
           {children}
@@ -147,64 +84,29 @@ function SelectLabel({ className, ...props }: React.ComponentProps<typeof Select
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn('py-1.5 ps-8 pe-2 text-xs text-muted-foreground font-medium', className)}
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
       {...props}
     />
   );
 }
 
 function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
-  const { indicatorPosition, indicatorVisibility, indicator } = React.useContext(SelectContext);
-
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 text-sm outline-hidden text-foreground hover:bg-accent focus:bg-accent data-disabled:pointer-events-none data-disabled:opacity-50',
-        indicatorPosition === 'left' ? 'ps-8 pe-2' : 'pe-8 ps-2',
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}
     >
-      {indicatorVisibility &&
-        (indicator && isValidElement(indicator) ? (
-          indicator
-        ) : (
-          <span
-            className={cn(
-              'absolute flex h-3.5 w-3.5 items-center justify-center',
-              indicatorPosition === 'left' ? 'start-2' : 'end-2'
-            )}
-          >
-            <SelectPrimitive.ItemIndicator>
-              <Check className="h-4 w-4 text-primary" />
-            </SelectPrimitive.ItemIndicator>
-          </span>
-        ))}
+      <span data-slot="select-item-indicator" className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  );
-}
-
-function SelectIndicator({
-  children,
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.ItemIndicator>) {
-  const { indicatorPosition } = React.useContext(SelectContext);
-
-  return (
-    <span
-      data-slot="select-indicator"
-      className={cn(
-        'absolute flex top-1/2 -translate-y-1/2 items-center justify-center',
-        indicatorPosition === 'left' ? 'start-2' : 'end-2',
-        className
-      )}
-      {...props}
-    >
-      <SelectPrimitive.ItemIndicator>{children}</SelectPrimitive.ItemIndicator>
-    </span>
   );
 }
 
@@ -212,9 +114,36 @@ function SelectSeparator({ className, ...props }: React.ComponentProps<typeof Se
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn('-mx-1.5 my-1.5 h-px bg-border', className)}
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
+  );
+}
+
+function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
   );
 }
 
@@ -222,7 +151,6 @@ export {
   Select,
   SelectContent,
   SelectGroup,
-  SelectIndicator,
   SelectItem,
   SelectLabel,
   SelectScrollDownButton,

--- a/packages/harmony/src/components/ui/select.tsx
+++ b/packages/harmony/src/components/ui/select.tsx
@@ -95,7 +95,7 @@ function SelectItem({ className, children, ...props }: React.ComponentProps<type
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_span:last-child]:flex [&_span:last-child]:items-center [&_span:last-child]:gap-2",
         className
       )}
       {...props}

--- a/packages/harmony/stories/components/select/index.stories.tsx
+++ b/packages/harmony/stories/components/select/index.stories.tsx
@@ -1,0 +1,246 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const meta = {
+  title: 'Components/Select',
+  component: SelectTrigger,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+A select component built on Radix UI's Select primitive, following shadcn/ui patterns. Displays a
+list of options for the user to pick one from, with full keyboard navigation and accessibility.
+
+## Features
+- Two trigger sizes (\`sm\`, \`default\`)
+- Grouped options with labels and separators
+- Selected-item check indicator
+- Disabled items and disabled control
+- Scroll up/down buttons for long lists
+- \`item-aligned\` (default) and \`popper\` positioning
+
+## Accessibility
+- Follows the WAI-ARIA listbox pattern
+- Full keyboard navigation (arrows, type-ahead, Home/End, Escape)
+- Focus management and disabled-state handling
+
+## Usage Guidelines
+- Compose \`Select\` with \`SelectTrigger\`, \`SelectValue\`, \`SelectContent\`, and \`SelectItem\`
+- Use \`SelectGroup\` + \`SelectLabel\` to organise related options
+- Use \`SelectSeparator\` between groups
+- Give the trigger an explicit width (e.g. \`className="w-[220px]"\`) for consistent layout
+`,
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      description: 'The size of the select trigger',
+      control: 'select',
+      options: ['sm', 'default'],
+      table: {
+        defaultValue: { summary: 'default' },
+      },
+    },
+    disabled: {
+      description: 'Whether the select trigger is disabled',
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof SelectTrigger>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Select>
+      <SelectTrigger className="w-[220px]" size={args.size}>
+        <SelectValue placeholder="Select a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+        <SelectItem value="blueberry">Blueberry</SelectItem>
+        <SelectItem value="grapes">Grapes</SelectItem>
+        <SelectItem value="pineapple">Pineapple</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'The default select with a placeholder and a handful of options.',
+      },
+    },
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Select>
+        <SelectTrigger className="w-[180px]" size="sm">
+          <SelectValue placeholder="Small" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="blueberry">Blueberry</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select>
+        <SelectTrigger className="w-[180px]" size="default">
+          <SelectValue placeholder="Default" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="blueberry">Blueberry</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'The `sm` and `default` trigger sizes side by side.',
+      },
+    },
+  },
+};
+
+export const WithGroupsAndLabels: Story = {
+  render: (args) => (
+    <Select>
+      <SelectTrigger className="w-[220px]" size={args.size}>
+        <SelectValue placeholder="Select a food" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Fruits</SelectLabel>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="blueberry">Blueberry</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Vegetables</SelectLabel>
+          <SelectItem value="carrot">Carrot</SelectItem>
+          <SelectItem value="potato">Potato</SelectItem>
+          <SelectItem value="spinach">Spinach</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Options organised into groups with labels and a separator between them.',
+      },
+    },
+  },
+};
+
+export const DisabledItems: Story = {
+  render: (args) => (
+    <Select>
+      <SelectTrigger className="w-[220px]" size={args.size}>
+        <SelectValue placeholder="Select a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana" disabled>
+          Banana (out of stock)
+        </SelectItem>
+        <SelectItem value="blueberry">Blueberry</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'An individual option can be disabled and is skipped during keyboard navigation.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <Select disabled>
+      <SelectTrigger className="w-[220px]" size={args.size}>
+        <SelectValue placeholder="Select a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'The entire control can be disabled via the `disabled` prop on `Select`.',
+      },
+    },
+  },
+};
+
+export const Scrolling: Story = {
+  render: (args) => (
+    <Select>
+      <SelectTrigger className="w-[220px]" size={args.size}>
+        <SelectValue placeholder="Select a timezone" />
+      </SelectTrigger>
+      <SelectContent>
+        {Array.from({ length: 30 }, (_, i) => (
+          <SelectItem key={i} value={`utc-${i}`}>
+            UTC+{i}:00
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'A long list of options exercises the scroll up/down buttons.',
+      },
+    },
+  },
+};
+
+export const Popper: Story = {
+  render: (args) => (
+    <Select>
+      <SelectTrigger className="w-[220px]" size={args.size}>
+        <SelectValue placeholder="Select a fruit" />
+      </SelectTrigger>
+      <SelectContent position="popper">
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+        <SelectItem value="blueberry">Blueberry</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Using `position="popper"` anchors the content below the trigger instead of over it.',
+      },
+    },
+  },
+};

--- a/packages/harmony/stories/components/select/index.stories.tsx
+++ b/packages/harmony/stories/components/select/index.stories.tsx
@@ -66,7 +66,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: (args) => (
-    <Select>
+    <Select disabled={args.disabled}>
       <SelectTrigger className="w-[220px]" size={args.size}>
         <SelectValue placeholder="Select a fruit" />
       </SelectTrigger>
@@ -179,8 +179,9 @@ export const DisabledItems: Story = {
 };
 
 export const Disabled: Story = {
+  args: { disabled: true },
   render: (args) => (
-    <Select disabled>
+    <Select disabled={args.disabled}>
       <SelectTrigger className="w-[220px]" size={args.size}>
         <SelectValue placeholder="Select a fruit" />
       </SelectTrigger>


### PR DESCRIPTION
## Summary
- Replace `Select` with the canonical shadcn implementation and remove the custom indicator context/props/export.
- Change `SelectTrigger` sizing to `sm` and `default`, and default `SelectContent` positioning to `item-aligned`.
- Normalize Tailwind v3-compatible utility classes across Harmony components to avoid silent no-op v4 utilities.
- Add Storybook coverage for the updated `Select` API and interaction variants.

## Testing
- Not run
- Updated Storybook stories for default, size, grouped, disabled, scrolling, and `popper` positioning cases.
- Added a changeset documenting the breaking `Select` API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Updated the Select component to a canonical shadcn-style API and appearance: default content positioning changed, trigger size options simplified, and selection now shows a built-in right-aligned checkmark.
  * Removed indicator customization APIs—custom indicators now require composing/wrapping Select items.
* **Bug Fixes**
  * Improved focus outline behavior and hover/highlight styling across multiple components.
  * Fixed RTL navigation and dropdown focus styling in Calendar.
  * Refined Context Menu, Popover, and Command styling for more consistent Tailwind behavior.
* **New Features**
  * Expanded Storybook coverage for Select variants, groups, disabled states, scrolling, and popper positioning.
* **Documentation / Chores**
  * Added guidance that Harmony targets Tailwind CSS v3, with v4→v3 class replacements and verification tips.
  * Updated Storybook host configuration to expose the dev server externally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->