### PR TITLE
Add linked resource commands and hostname APIs

### DIFF
--- a/.changeset/cli-resource-commands-and-hostnames.md
+++ b/.changeset/cli-resource-commands-and-hostnames.md
@@ -1,0 +1,19 @@
+---
+'@gigadrive/sdk': minor
+'gigadrive': minor
+---
+
+Add application hostname management to the SDK and broaden CLI coverage of the Gigadrive Network API.
+
+**@gigadrive/sdk**
+
+- `client.applications.checkHostnameAvailability(applicationId, label)` — check whether a production hostname label is available (`GET /applications/:id/hostname/availability`).
+- `client.applications.setProductionHostname(applicationId, label)` — set the application's production hostname (`PUT /applications/:id/hostname`).
+- New exported types `HostnameAvailability` and `SetProductionHostnameResult`.
+
+**gigadrive (CLI)**
+
+- New `ApiClientService` — a single, shared factory for the authenticated `@gigadrive/sdk` client used by every API-backed command. `DeploymentApiService` now delegates to it.
+- Project linking: `gigadrive link` / `gigadrive unlink` persist the selected application to `.gigadrive/project.json`; `gigadrive platform deploy` now deploys to the linked application (or `--app`) instead of a hard-coded ID and prints the real `*.gigadrive.app` hostname on success.
+- New commands: `gigadrive apps list`, `gigadrive env list|set|rm`, `gigadrive deployments list|inspect`, `gigadrive ai usage|budgets|policies|models|chat`, and `gigadrive logout`.
+- `GIGADRIVE_API_BASE_URL` now defaults to the production API (`https://api.gigadrive.network`), and the CLI version is sourced from `package.json`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -17,19 +17,35 @@ packages/cli/
       oauth-config.ts           # OAuthConfigService — OIDC discovery + env config
       auth-storage.ts           # AuthStorageService — ~/.gigadrive/auth.json persistence
       auth.ts                   # AuthService — login, logout, token refresh, user info
+      api-client.ts             # ApiClientService — shared @gigadrive/sdk client factory
       project-config.ts         # ProjectConfigService — gigadrive.yaml resolution
+      project-link.ts           # ProjectLinkService — .gigadrive/project.json (app link)
       package-manager.ts        # PackageManagerService — detect npm/yarn/pnpm/bun
       archive.ts                # ArchiveService — zip archive creation
-      deployment-api.ts         # DeploymentApiService — deployment API client
+      deployment-api.ts         # DeploymentApiService — deployment flow over ApiClientService
     commands/
       login/index.ts            # `gigadrive login`
+      logout/index.ts           # `gigadrive logout`
       whoami/index.ts           # `gigadrive whoami`
+      link/index.ts             # `gigadrive link` / `gigadrive unlink`
+      apps/index.ts             # `gigadrive apps list`
+      env/index.ts              # `gigadrive env list|set|rm`
+      deployments/index.ts      # `gigadrive deployments list|inspect`
+      ai/index.ts               # `gigadrive ai usage|budgets|policies|models|chat`
       build/index.ts            # `gigadrive build`
       debug/index.ts            # `gigadrive debug` (parent)
       debug/config/index.ts     # `gigadrive debug config`
       platform/index.ts         # `gigadrive platform` (parent)
       platform/deploy/index.ts  # `gigadrive platform deploy`
 ```
+
+Every command that talks to the Gigadrive Network API obtains its client from
+**`ApiClientService`** — `getClient` for a raw `GigadriveClient` (used for
+streaming, e.g. `ai chat --stream`), or `request(fn)` to run an SDK call and map
+failures to a tagged `ApiRequestError`. `DeploymentApiService` is a thin wrapper
+over `ApiClientService` that keeps deployment-specific errors. Resource commands
+resolve their target application/organization from `ProjectLinkService`
+(`.gigadrive/project.json`), overridable with `--app` / `--org`.
 
 ## Architecture Overview
 
@@ -54,25 +70,35 @@ AuthService
   ├── OAuthConfigService (OIDC discovery, env config)
   └── AuthStorageService (file-based token persistence)
 
+ApiClientService         (requires AuthService — builds an authenticated @gigadrive/sdk client)
+DeploymentApiService     (requires ApiClientService — deployment flow + deployment errors)
 ProjectConfigService     (standalone — wraps @gigadrive/network-config)
+ProjectLinkService       (standalone — reads/writes .gigadrive/project.json)
 PackageManagerService    (standalone — detects npm/yarn/pnpm/bun)
 ArchiveService           (standalone — zip creation with ignore rules)
-DeploymentApiService     (standalone — HTTP API client)
 ```
 
-All layers are composed flat in `src/index.ts`:
+All layers are composed flat in `src/index.ts`. `ApiClientService` and
+`DeploymentApiService` are provided `BaseServices` (which supplies `AuthService`):
 
 ```ts
-const ServicesLive = Layer.mergeAll(
+const BaseServices = Layer.mergeAll(
   OAuthConfigService.Default,
   AuthStorageService.Default,
-  ProjectConfigService.Default,
   PackageManagerService.Default,
   ArchiveService.Default,
-  DeploymentApiService.Default
+  NetworkConfigLive,
+  ProjectConfigService.Default,
+  ProjectLinkService.Default
 ).pipe(Layer.provideMerge(AuthService.Default));
 
-const AppLive = Layer.mergeAll(ServicesLive, NodeContext.layer, Logger.minimumLogLevel(LogLevel.Info));
+const ApiClientLive = Layer.provide(ApiClientService.Default, BaseServices);
+const DeploymentApiLive = Layer.provide(DeploymentApiService.Default, BaseServices);
+
+const ServicesLive = Layer.mergeAll(BaseServices, ApiClientLive, DeploymentApiLive);
+const AppLive = Layer.mergeAll(ServicesLive, Logger.minimumLogLevel(LogLevel.Info)).pipe(
+  Layer.provideMerge(NodeContext.layer)
+);
 ```
 
 ## Best Practices Enforced in This Package
@@ -311,11 +337,11 @@ const data = Option.getOrThrow(stored);
 
 ## Environment Variables
 
-| Variable                             | Default                    | Description             |
-| ------------------------------------ | -------------------------- | ----------------------- |
-| `GIGADRIVE_NETWORK_OAUTH_ISSUER_URL` | `https://idp.gigadrive.de` | OIDC issuer URL         |
-| `GIGADRIVE_NETWORK_OAUTH_CLIENT_ID`  | `todo_add_client_id`       | OAuth client ID         |
-| `GIGADRIVE_API_BASE_URL`             | `http://localhost:3000`    | Deployment API base URL |
+| Variable                             | Default                        | Description                      |
+| ------------------------------------ | ------------------------------ | -------------------------------- |
+| `GIGADRIVE_NETWORK_OAUTH_ISSUER_URL` | `https://idp.gigadrive.de`     | OIDC issuer URL                  |
+| `GIGADRIVE_NETWORK_OAUTH_CLIENT_ID`  | `todo_add_client_id`           | OAuth client ID (set the real first-party CLI client ID before shipping) |
+| `GIGADRIVE_API_BASE_URL`             | `https://api.gigadrive.network` | Gigadrive Network API base URL (used by `ApiClientService`) |
 
 All read via `Config.string()` with defaults — never accessed via `process.env`.
 

--- a/packages/cli/src/commands/ai/index.ts
+++ b/packages/cli/src/commands/ai/index.ts
@@ -1,0 +1,348 @@
+import { Args, Command, Options } from '@effect/cli';
+import { FileSystem } from '@effect/platform';
+import type { AiGatewayBudgetInput, AiGatewayPolicyInput } from '@gigadrive/sdk';
+import { Console, Effect, Option } from 'effect';
+import { ApiRequestError, ProjectNotLinkedError } from '../../errors';
+import { ApiClientService } from '../../services/api-client';
+import { ProjectLinkService } from '../../services/project-link';
+
+// ---------------------------------------------------------------------------
+// Shared options / helpers
+// ---------------------------------------------------------------------------
+
+const orgOption = Options.text('org').pipe(
+  Options.withAlias('o'),
+  Options.withDescription('Organization ID (defaults to the linked organization)'),
+  Options.optional
+);
+
+const appOption = Options.text('app').pipe(
+  Options.withAlias('a'),
+  Options.withDescription('Restrict to this application ID'),
+  Options.optional
+);
+
+const fromOption = Options.text('from').pipe(
+  Options.withDescription('Include usage at or after this ISO 8601 timestamp'),
+  Options.optional
+);
+
+const toOption = Options.text('to').pipe(
+  Options.withDescription('Include usage before or at this ISO 8601 timestamp'),
+  Options.optional
+);
+
+const fileOption = Options.text('file').pipe(
+  Options.withAlias('f'),
+  Options.withDescription('Path to a JSON file, or "-" for stdin (default: stdin)'),
+  Options.optional
+);
+
+/** Resolve the organization ID from `--org` or the linked project. */
+const resolveOrgId = (org: Option.Option<string>) =>
+  Effect.gen(function* () {
+    if (Option.isSome(org)) return org.value;
+    const projectLink = yield* ProjectLinkService;
+    const link = yield* projectLink.resolve(process.cwd());
+    if (link.organizationId === undefined) {
+      return yield* Effect.fail(
+        new ProjectNotLinkedError({
+          message: 'No organization is linked. Pass --org <id> or re-run "gigadrive link".',
+          directory: process.cwd(),
+        })
+      );
+    }
+    return link.organizationId;
+  });
+
+/** Read all of stdin as a UTF-8 string. */
+const readStdin = Effect.async<string, ApiRequestError>((resume) => {
+  let data = '';
+  const stdin = process.stdin;
+  stdin.setEncoding('utf8');
+  const onData = (chunk: string) => {
+    data += chunk;
+  };
+  const cleanup = () => {
+    stdin.off('data', onData);
+    stdin.off('end', onEnd);
+    stdin.off('error', onError);
+  };
+  const onEnd = () => {
+    cleanup();
+    resume(Effect.succeed(data));
+  };
+  const onError = (err: Error) => {
+    cleanup();
+    resume(Effect.fail(new ApiRequestError({ message: `Failed to read stdin: ${err.message}` })));
+  };
+  stdin.on('data', onData);
+  stdin.on('end', onEnd);
+  stdin.on('error', onError);
+  stdin.resume();
+});
+
+/** Read JSON from a file (or stdin when the path is omitted or `-`). */
+const readJsonInput = (file: Option.Option<string>) =>
+  Effect.gen(function* () {
+    const path = Option.getOrUndefined(file);
+    let raw: string;
+    if (path === undefined || path === '-') {
+      raw = yield* readStdin;
+    } else {
+      const fs = yield* FileSystem.FileSystem;
+      raw = yield* fs
+        .readFileString(path, 'utf8')
+        .pipe(Effect.mapError((e) => new ApiRequestError({ message: `Failed to read ${path}: ${String(e)}` })));
+    }
+    return yield* Effect.try({
+      try: () => JSON.parse(raw) as unknown,
+      catch: () => new ApiRequestError({ message: 'Input is not valid JSON.' }),
+    });
+  });
+
+/** Shared error handlers for the governance commands. */
+const governanceErrorHandlers = {
+  NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+  ApiRequestError: (err: ApiRequestError) => Console.error(err.message),
+  ProjectNotLinkedError: (err: ProjectNotLinkedError) => Console.error(err.message),
+  ProjectLinkReadError: (err: { message: string }) => Console.error(err.message),
+};
+
+// ---------------------------------------------------------------------------
+// ai usage
+// ---------------------------------------------------------------------------
+
+const usageSummaryCommand = Command.make(
+  'summary',
+  { org: orgOption, app: appOption, from: fromOption, to: toOption },
+  ({ org, app, from, to }) =>
+    Effect.gen(function* () {
+      const apiClient = yield* ApiClientService;
+      const orgId = yield* resolveOrgId(org);
+      const summary = yield* apiClient.request((client) =>
+        client.organizations.aiGateway.usage.summary(orgId, {
+          applicationId: Option.getOrUndefined(app),
+          from: Option.getOrUndefined(from),
+          to: Option.getOrUndefined(to),
+        })
+      );
+      yield* Console.log(JSON.stringify(summary, null, 2));
+    }).pipe(Effect.catchTags(governanceErrorHandlers))
+);
+
+const usageRequestsCommand = Command.make(
+  'requests',
+  { org: orgOption, app: appOption, from: fromOption, to: toOption },
+  ({ org, app, from, to }) =>
+    Effect.gen(function* () {
+      const apiClient = yield* ApiClientService;
+      const orgId = yield* resolveOrgId(org);
+      const { items, total } = yield* apiClient.request((client) =>
+        client.organizations.aiGateway.usage.requests(orgId, {
+          applicationId: Option.getOrUndefined(app),
+          from: Option.getOrUndefined(from),
+          to: Option.getOrUndefined(to),
+        })
+      );
+      if (items.length === 0) {
+        yield* Console.log('No AI Gateway requests found.');
+        return;
+      }
+      for (const e of items) {
+        yield* Console.log(
+          `${e.createdAt}  ${e.modelRequested}  ${e.status}  ${e.totalTokens} tok  ${e.billableCostMicros}µ$`
+        );
+      }
+      yield* Console.log(`\n${total} request(s).`);
+    }).pipe(Effect.catchTags(governanceErrorHandlers))
+);
+
+const outOption = Options.text('out').pipe(
+  Options.withDescription('Write the CSV to this file instead of stdout'),
+  Options.optional
+);
+
+const usageExportCommand = Command.make(
+  'export',
+  { org: orgOption, app: appOption, from: fromOption, to: toOption, out: outOption },
+  ({ org, app, from, to, out }) =>
+    Effect.gen(function* () {
+      const apiClient = yield* ApiClientService;
+      const orgId = yield* resolveOrgId(org);
+      const csv = yield* apiClient.request((client) =>
+        client.organizations.aiGateway.usage.export(orgId, {
+          applicationId: Option.getOrUndefined(app),
+          from: Option.getOrUndefined(from),
+          to: Option.getOrUndefined(to),
+        })
+      );
+      const outPath = Option.getOrUndefined(out);
+      if (outPath === undefined) {
+        yield* Console.log(csv);
+      } else {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs
+          .writeFileString(outPath, csv)
+          .pipe(Effect.mapError((e) => new ApiRequestError({ message: `Failed to write ${outPath}: ${String(e)}` })));
+        yield* Console.log(`Wrote ${outPath}.`);
+      }
+    }).pipe(Effect.catchTags(governanceErrorHandlers))
+);
+
+const usageCommand = Command.make('usage', {}, () => Effect.void).pipe(
+  Command.withSubcommands([usageSummaryCommand, usageRequestsCommand, usageExportCommand])
+);
+
+// ---------------------------------------------------------------------------
+// ai budgets
+// ---------------------------------------------------------------------------
+
+const budgetsGetCommand = Command.make('get', { org: orgOption }, ({ org }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const orgId = yield* resolveOrgId(org);
+    const { items } = yield* apiClient.request((client) => client.organizations.aiGateway.budgets.list(orgId));
+    yield* Console.log(JSON.stringify(items, null, 2));
+  }).pipe(Effect.catchTags(governanceErrorHandlers))
+);
+
+const budgetsSetCommand = Command.make('set', { org: orgOption, file: fileOption }, ({ org, file }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const orgId = yield* resolveOrgId(org);
+    const parsed = yield* readJsonInput(file);
+    const budgets = Array.isArray(parsed) ? parsed : (parsed as { budgets?: unknown }).budgets;
+    if (!Array.isArray(budgets)) {
+      yield* Console.error('Expected a JSON array of budgets, or an object of the form { "budgets": [...] }.');
+      return;
+    }
+    const { items } = yield* apiClient.request((client) =>
+      client.organizations.aiGateway.budgets.replace(orgId, budgets as AiGatewayBudgetInput[])
+    );
+    yield* Console.log(`Saved ${items.length} budget(s).`);
+  }).pipe(Effect.catchTags(governanceErrorHandlers))
+);
+
+const budgetsCommand = Command.make('budgets', {}, () => Effect.void).pipe(
+  Command.withSubcommands([budgetsGetCommand, budgetsSetCommand])
+);
+
+// ---------------------------------------------------------------------------
+// ai policies
+// ---------------------------------------------------------------------------
+
+const policiesGetCommand = Command.make('get', { org: orgOption, app: appOption }, ({ org, app }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const orgId = yield* resolveOrgId(org);
+    const policy = yield* apiClient.request((client) =>
+      client.organizations.aiGateway.policies.get(orgId, { applicationId: Option.getOrUndefined(app) })
+    );
+    yield* Console.log(policy === null ? 'No policy set.' : JSON.stringify(policy, null, 2));
+  }).pipe(Effect.catchTags(governanceErrorHandlers))
+);
+
+const policiesSetCommand = Command.make('set', { org: orgOption, file: fileOption }, ({ org, file }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const orgId = yield* resolveOrgId(org);
+    const parsed = yield* readJsonInput(file);
+    const policy = yield* apiClient.request((client) =>
+      client.organizations.aiGateway.policies.put(orgId, parsed as AiGatewayPolicyInput)
+    );
+    yield* Console.log(`Policy saved${policy.applicationId ? ` for application ${policy.applicationId}` : ''}.`);
+  }).pipe(Effect.catchTags(governanceErrorHandlers))
+);
+
+const policiesCommand = Command.make('policies', {}, () => Effect.void).pipe(
+  Command.withSubcommands([policiesGetCommand, policiesSetCommand])
+);
+
+// ---------------------------------------------------------------------------
+// ai models
+// ---------------------------------------------------------------------------
+
+const inferenceErrorHandlers = {
+  NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+  ApiRequestError: (err: ApiRequestError) => Console.error(err.message),
+};
+
+const modelsListCommand = Command.make('list', {}, () =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const { items } = yield* apiClient.request((client) => client.aiGateway.listModels());
+    for (const m of items) {
+      yield* Console.log(`${m.id}  ${m.name}  (ctx ${m.contextWindow})`);
+    }
+  }).pipe(Effect.catchTags(inferenceErrorHandlers))
+);
+
+const modelIdArg = Args.text({ name: 'model-id' }).pipe(Args.withDescription('The model ID, e.g. openai/gpt-4o'));
+
+const modelsGetCommand = Command.make('get', { modelId: modelIdArg }, ({ modelId }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const model = yield* apiClient.request((client) => client.aiGateway.getModel(modelId));
+    yield* Console.log(JSON.stringify(model, null, 2));
+  }).pipe(Effect.catchTags(inferenceErrorHandlers))
+);
+
+const modelsCommand = Command.make('models', {}, () => Effect.void).pipe(
+  Command.withSubcommands([modelsListCommand, modelsGetCommand])
+);
+
+// ---------------------------------------------------------------------------
+// ai chat
+// ---------------------------------------------------------------------------
+
+const modelOption = Options.text('model').pipe(
+  Options.withAlias('m'),
+  Options.withDescription('The model ID to use, e.g. openai/gpt-4o')
+);
+
+const streamOption = Options.boolean('stream').pipe(Options.withDescription('Stream the response token by token'));
+
+const promptArg = Args.text({ name: 'prompt' }).pipe(
+  Args.withDescription('The prompt text, or "-" to read from stdin')
+);
+
+const chatCommand = Command.make(
+  'chat',
+  { prompt: promptArg, model: modelOption, stream: streamOption },
+  ({ prompt, model, stream }) =>
+    Effect.gen(function* () {
+      const apiClient = yield* ApiClientService;
+      const text = prompt === '-' ? yield* readStdin : prompt;
+      const messages = [{ role: 'user', content: text }];
+
+      if (stream) {
+        const client = yield* apiClient.getClient;
+        yield* Effect.tryPromise({
+          try: async () => {
+            for await (const chunk of client.aiGateway.chatCompletionsStream({ model, messages })) {
+              process.stdout.write(chunk.choices[0]?.delta?.content ?? '');
+            }
+            process.stdout.write('\n');
+          },
+          catch: (error) => new ApiRequestError({ message: error instanceof Error ? error.message : String(error) }),
+        });
+        return;
+      }
+
+      const response = yield* apiClient.request((client) => client.aiGateway.chatCompletions({ model, messages }));
+      const content = response.choices[0]?.message.content;
+      yield* Console.log(typeof content === 'string' ? content : JSON.stringify(content));
+    }).pipe(Effect.catchTags(inferenceErrorHandlers))
+);
+
+// ---------------------------------------------------------------------------
+// ai (parent)
+// ---------------------------------------------------------------------------
+
+const aiBase = Command.make('ai', {}, () => Effect.void);
+
+/** `gigadrive ai` — AI Gateway governance (usage, budgets, policies) and inference (models, chat). */
+export const aiCommand = aiBase.pipe(
+  Command.withSubcommands([usageCommand, budgetsCommand, policiesCommand, modelsCommand, chatCommand])
+);

--- a/packages/cli/src/commands/apps/index.ts
+++ b/packages/cli/src/commands/apps/index.ts
@@ -1,0 +1,37 @@
+import { Command, Options } from '@effect/cli';
+import { Console, Effect, Option } from 'effect';
+import { ApiClientService } from '../../services/api-client';
+
+const orgOption = Options.text('org').pipe(
+  Options.withAlias('o'),
+  Options.withDescription('Only list applications belonging to this organization ID'),
+  Options.optional
+);
+
+const appsListCommand = Command.make('list', { org: orgOption }, ({ org }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const organizationId = Option.getOrUndefined(org);
+    const { items, total } = yield* apiClient.request((client) => client.applications.list({ organizationId }));
+
+    if (items.length === 0) {
+      yield* Console.log('No applications found.');
+      return;
+    }
+
+    for (const app of items) {
+      yield* Console.log(`${app.id}  ${app.name}  (${app.organization.name})`);
+    }
+    yield* Console.log(`\n${total} application(s).`);
+  }).pipe(
+    Effect.catchTags({
+      NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+      ApiRequestError: (err) => Console.error(`Failed to list applications: ${err.message}`),
+    })
+  )
+);
+
+const appsBase = Command.make('apps', {}, () => Effect.void);
+
+/** `gigadrive apps` — inspect the applications the authenticated actor can access. */
+export const appsCommand = appsBase.pipe(Command.withSubcommands([appsListCommand]));

--- a/packages/cli/src/commands/deployments/index.ts
+++ b/packages/cli/src/commands/deployments/index.ts
@@ -1,0 +1,110 @@
+import { Args, Command, Options } from '@effect/cli';
+import { Console, Effect, Option } from 'effect';
+import { ApiClientService } from '../../services/api-client';
+import { ProjectLinkService } from '../../services/project-link';
+
+const DEPLOYMENT_STATUSES = ['PENDING', 'QUEUED', 'STARTING', 'BUILDING', 'PROVISIONING', 'ACTIVE', 'FAILED'] as const;
+
+const appOption = Options.text('app').pipe(
+  Options.withAlias('a'),
+  Options.withDescription('Filter by application ID (defaults to the linked application)'),
+  Options.optional
+);
+
+const orgOption = Options.text('org').pipe(
+  Options.withAlias('o'),
+  Options.withDescription('Filter by organization ID'),
+  Options.optional
+);
+
+const statusOption = Options.choice('status', DEPLOYMENT_STATUSES).pipe(
+  Options.withAlias('s'),
+  Options.withDescription('Filter by deployment status'),
+  Options.optional
+);
+
+/**
+ * Resolve the application filter: an explicit `--app` wins, otherwise fall back
+ * to the linked application (when the directory is linked). Never fails — an
+ * unlinked directory simply yields no application filter.
+ */
+const resolveApplicationFilter = (app: Option.Option<string>) =>
+  Option.match(app, {
+    onSome: (id) => Effect.succeed<string | undefined>(id),
+    onNone: () =>
+      Effect.gen(function* () {
+        const projectLink = yield* ProjectLinkService;
+        const link = yield* projectLink.load(process.cwd()).pipe(Effect.catchAll(() => Effect.succeed(Option.none())));
+        return Option.match(link, { onNone: () => undefined, onSome: (l) => l.applicationId });
+      }),
+  });
+
+const deploymentsListCommand = Command.make(
+  'list',
+  { app: appOption, org: orgOption, status: statusOption },
+  ({ app, org, status }) =>
+    Effect.gen(function* () {
+      const apiClient = yield* ApiClientService;
+      const applicationId = yield* resolveApplicationFilter(app);
+
+      const { items, total } = yield* apiClient.request((client) =>
+        client.deployments.list({
+          applicationId,
+          organizationId: Option.getOrUndefined(org),
+          status: Option.getOrUndefined(status),
+        })
+      );
+
+      if (items.length === 0) {
+        yield* Console.log('No deployments found.');
+        return;
+      }
+
+      for (const d of items) {
+        yield* Console.log(`${d.id}  ${d.status.padEnd(12)}  ${d.createdAt}`);
+      }
+      yield* Console.log(`\n${total} deployment(s).`);
+    }).pipe(
+      Effect.catchTags({
+        NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+        ApiRequestError: (err) => Console.error(`Failed to list deployments: ${err.message}`),
+      })
+    )
+);
+
+const deploymentIdArg = Args.text({ name: 'deployment-id' }).pipe(Args.withDescription('The deployment ID to inspect'));
+
+const deploymentsInspectCommand = Command.make('inspect', { deploymentId: deploymentIdArg }, ({ deploymentId }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+
+    const deployment = yield* apiClient.request((client) => client.deployments.get(deploymentId));
+    yield* Console.log(`ID:          ${deployment.id}`);
+    yield* Console.log(`Application:  ${deployment.applicationId}`);
+    yield* Console.log(`Status:      ${deployment.status}`);
+    yield* Console.log(`Created:     ${deployment.createdAt}`);
+    yield* Console.log(`Updated:     ${deployment.updatedAt}`);
+
+    const hostnames = yield* apiClient
+      .request((client) => client.deployments.getHostnames(deploymentId))
+      .pipe(Effect.catchAll(() => Effect.succeed({ items: [], total: 0 })));
+    if (hostnames.items.length > 0) {
+      yield* Console.log('Hostnames:');
+      for (const h of hostnames.items) {
+        yield* Console.log(`  https://${h.hostname}${h.active ? '' : ' (inactive)'}`);
+      }
+    }
+  }).pipe(
+    Effect.catchTags({
+      NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+      ApiRequestError: (err) => Console.error(`Failed to inspect deployment: ${err.message}`),
+    })
+  )
+);
+
+const deploymentsBase = Command.make('deployments', {}, () => Effect.void);
+
+/** `gigadrive deployments` — list and inspect deployments. */
+export const deploymentsCommand = deploymentsBase.pipe(
+  Command.withSubcommands([deploymentsListCommand, deploymentsInspectCommand])
+);

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -1,0 +1,152 @@
+import { Args, Command, Options } from '@effect/cli';
+import { Console, Effect, Option } from 'effect';
+import { ApiClientService } from '../../services/api-client';
+import { ProjectLinkService } from '../../services/project-link';
+
+const appOption = Options.text('app').pipe(
+  Options.withAlias('a'),
+  Options.withDescription('Operate on this application (overrides the linked application)'),
+  Options.optional
+);
+
+const orgOption = Options.text('org').pipe(
+  Options.withAlias('o'),
+  Options.withDescription('Operate on this organization instead of an application'),
+  Options.optional
+);
+
+const sensitiveOption = Options.boolean('sensitive').pipe(
+  Options.withDescription('Store the value as sensitive (hidden in API responses)')
+);
+
+const envIdOption = Options.text('env').pipe(
+  Options.withAlias('e'),
+  Options.withDescription('Environment ID for an environment-scoped variable (application scope only)'),
+  Options.optional
+);
+
+const keyValueArg = Args.text({ name: 'key=value' }).pipe(
+  Args.withDescription('Variable assignment, e.g. DATABASE_URL=postgres://user:pass@host/db')
+);
+
+const keyOrIdArg = Args.text({ name: 'key-or-id' }).pipe(Args.withDescription('Variable key or ID to remove'));
+
+/**
+ * Resolve which resource the command operates on: an explicit `--org` selects
+ * organization scope; otherwise application scope using `--app` or the linked
+ * application. Fails with `ProjectNotLinkedError` when neither is available.
+ */
+const resolveScope = (app: Option.Option<string>, org: Option.Option<string>) =>
+  Effect.gen(function* () {
+    if (Option.isSome(org)) {
+      return { kind: 'organization' as const, id: org.value };
+    }
+    const projectLink = yield* ProjectLinkService;
+    const id = yield* Option.match(app, {
+      onSome: (value) => Effect.succeed(value),
+      onNone: () => projectLink.resolve(process.cwd()).pipe(Effect.map((link) => link.applicationId)),
+    });
+    return { kind: 'application' as const, id };
+  });
+
+const envListCommand = Command.make('list', { app: appOption, org: orgOption }, ({ app, org }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const scope = yield* resolveScope(app, org);
+
+    const { items } = yield* apiClient.request((client) =>
+      scope.kind === 'organization'
+        ? client.organizations.envVars.list(scope.id)
+        : client.applications.envVars.list(scope.id)
+    );
+
+    if (items.length === 0) {
+      yield* Console.log('No environment variables set.');
+      return;
+    }
+    for (const v of items) {
+      yield* Console.log(`${v.key}=${v.sensitive ? '***' : (v.value ?? '')}`);
+    }
+  }).pipe(
+    Effect.catchTags({
+      NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+      ApiRequestError: (err) => Console.error(`Failed to list environment variables: ${err.message}`),
+      ProjectNotLinkedError: (err) => Console.error(err.message),
+      ProjectLinkReadError: (err) => Console.error(err.message),
+    })
+  )
+);
+
+const envSetCommand = Command.make(
+  'set',
+  { keyValue: keyValueArg, app: appOption, org: orgOption, sensitive: sensitiveOption, env: envIdOption },
+  ({ keyValue, app, org, sensitive, env }) =>
+    Effect.gen(function* () {
+      const separator = keyValue.indexOf('=');
+      if (separator <= 0) {
+        yield* Console.error('Invalid format. Use KEY=VALUE, e.g. "gigadrive env set DATABASE_URL=postgres://...".');
+        return;
+      }
+      const key = keyValue.slice(0, separator);
+      const value = keyValue.slice(separator + 1);
+
+      const apiClient = yield* ApiClientService;
+      const scope = yield* resolveScope(app, org);
+      const environmentId = Option.getOrUndefined(env);
+
+      const created = yield* apiClient.request((client) =>
+        scope.kind === 'organization'
+          ? client.organizations.envVars.create(scope.id, { key, value, sensitive })
+          : client.applications.envVars.create(scope.id, { key, value, sensitive, environmentId })
+      );
+      yield* Console.log(`Set ${created.key}.`);
+    }).pipe(
+      Effect.catchTags({
+        NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+        ApiRequestError: (err) => Console.error(`Failed to set environment variable: ${err.message}`),
+        ProjectNotLinkedError: (err) => Console.error(err.message),
+        ProjectLinkReadError: (err) => Console.error(err.message),
+      })
+    )
+);
+
+const envRmCommand = Command.make(
+  'rm',
+  { keyOrId: keyOrIdArg, app: appOption, org: orgOption },
+  ({ keyOrId, app, org }) =>
+    Effect.gen(function* () {
+      const apiClient = yield* ApiClientService;
+      const scope = yield* resolveScope(app, org);
+
+      const { items } = yield* apiClient.request((client) =>
+        scope.kind === 'organization'
+          ? client.organizations.envVars.list(scope.id)
+          : client.applications.envVars.list(scope.id)
+      );
+
+      const target = items.find((v) => v.id === keyOrId || v.key === keyOrId);
+      if (target === undefined) {
+        yield* Console.error(`No environment variable matching "${keyOrId}".`);
+        return;
+      }
+
+      yield* apiClient.request((client) =>
+        scope.kind === 'organization'
+          ? client.organizations.envVars.delete(scope.id, target.id)
+          : client.applications.envVars.delete(scope.id, target.id)
+      );
+      yield* Console.log(`Removed ${target.key}.`);
+    }).pipe(
+      Effect.catchTags({
+        NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+        ApiRequestError: (err) => Console.error(`Failed to remove environment variable: ${err.message}`),
+        ProjectNotLinkedError: (err) => Console.error(err.message),
+        ProjectLinkReadError: (err) => Console.error(err.message),
+      })
+    )
+);
+
+const envBase = Command.make('env', {}, () => Effect.void);
+
+/** `gigadrive env` — manage environment variables for the linked app or an organization. */
+export const envCommand = envBase.pipe(Command.withSubcommands([envListCommand, envSetCommand, envRmCommand]));

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -1,0 +1,90 @@
+import { Command, Options, Prompt } from '@effect/cli';
+import { Console, Effect, Option } from 'effect';
+import { ApiClientService } from '../../services/api-client';
+import { ProjectLinkService } from '../../services/project-link';
+
+const appOption = Options.text('app').pipe(
+  Options.withAlias('a'),
+  Options.withDescription('Application ID to link (skips the interactive picker)'),
+  Options.optional
+);
+
+const orgOption = Options.text('org').pipe(
+  Options.withAlias('o'),
+  Options.withDescription('Only list applications belonging to this organization ID'),
+  Options.optional
+);
+
+/**
+ * `gigadrive link` — associate the current directory with an application by
+ * writing `.gigadrive/project.json`. Deploy and the resource commands read it.
+ */
+export const linkCommand = Command.make('link', { app: appOption, org: orgOption }, ({ app, org }) =>
+  Effect.gen(function* () {
+    const apiClient = yield* ApiClientService;
+    const projectLink = yield* ProjectLinkService;
+    const cwd = process.cwd();
+
+    const organizationId = Option.getOrUndefined(org);
+    const { items: apps } = yield* apiClient.request((client) => client.applications.list({ organizationId }));
+
+    if (apps.length === 0) {
+      yield* Console.error(
+        'No applications found. Create one in the Gigadrive console, then run "gigadrive link" again.'
+      );
+      return;
+    }
+
+    const explicitAppId = Option.getOrUndefined(app);
+
+    let applicationId: string;
+    let linkedOrganizationId: string | undefined;
+
+    if (explicitAppId !== undefined) {
+      const match = apps.find((a) => a.id === explicitAppId);
+      if (match === undefined) {
+        yield* Console.error(`Application "${explicitAppId}" was not found among your applications.`);
+        return;
+      }
+      applicationId = match.id;
+      linkedOrganizationId = match.organization.id;
+    } else if (apps.length === 1) {
+      applicationId = apps[0].id;
+      linkedOrganizationId = apps[0].organization.id;
+    } else {
+      const chosen = yield* Prompt.run(
+        Prompt.select({
+          message: 'Select an application to link',
+          choices: apps.map((a) => ({ title: `${a.name} (${a.organization.name})`, value: a })),
+        })
+      );
+      applicationId = chosen.id;
+      linkedOrganizationId = chosen.organization.id;
+    }
+
+    yield* projectLink.save(cwd, { applicationId, organizationId: linkedOrganizationId });
+
+    yield* Console.log(`Linked this directory to application ${applicationId}.`);
+    yield* Console.log('Tip: add ".gigadrive/" to your .gitignore.');
+  }).pipe(
+    Effect.catchTags({
+      QuitException: () => Console.log('Cancelled.'),
+      NotAuthenticatedError: () => Console.error('You are not logged in. Run "gigadrive login" to authenticate.'),
+      ApiRequestError: (err) => Console.error(`Failed to list applications: ${err.message}`),
+      ProjectLinkWriteError: (err) => Console.error(err.message),
+    })
+  )
+);
+
+/** `gigadrive unlink` — remove the current directory's `.gigadrive/project.json`. */
+export const unlinkCommand = Command.make('unlink', {}, () =>
+  Effect.gen(function* () {
+    const projectLink = yield* ProjectLinkService;
+    yield* projectLink.remove(process.cwd());
+    yield* Console.log('Unlinked this directory.');
+  }).pipe(
+    Effect.catchTags({
+      ProjectLinkWriteError: (err) => Console.error(err.message),
+    })
+  )
+);

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -1,0 +1,16 @@
+import { Command } from '@effect/cli';
+import { Console, Effect } from 'effect';
+import { AuthService } from '../../services/auth';
+
+/** `gigadrive logout` — clear stored credentials (`~/.gigadrive/auth.json`). */
+export const logoutCommand = Command.make('logout', {}, () =>
+  Effect.gen(function* () {
+    const auth = yield* AuthService;
+    yield* auth.logout;
+    yield* Console.log('Logged out.');
+  }).pipe(
+    Effect.catchTags({
+      AuthStorageWriteError: (err) => Console.error(`Failed to log out: ${err.message}`),
+    })
+  )
+);

--- a/packages/cli/src/commands/platform/deploy/index.ts
+++ b/packages/cli/src/commands/platform/deploy/index.ts
@@ -1,22 +1,37 @@
-import { Command } from '@effect/cli';
+import { Command, Options } from '@effect/cli';
 import { FileSystem, Path } from '@effect/platform';
 import { formatFileSize } from '@gigadrive/commons';
-import { Console, Duration, Effect, Schedule, Stream } from 'effect';
+import { Console, Duration, Effect, Option, Schedule, Stream } from 'effect';
 import * as os from 'node:os';
 import type { DeploymentId, DeploymentLog, DeploymentStatus } from '../../../domain';
 import { DeploymentFailedError, UploadPartError } from '../../../errors';
 import { ArchiveService } from '../../../services/archive';
 import { DeploymentApiService } from '../../../services/deployment-api';
 import { ProjectConfigService } from '../../../services/project-config';
+import { ProjectLinkService } from '../../../services/project-link';
 
-export const deployCommand = Command.make('deploy', {}, () =>
+const appOption = Options.text('app').pipe(
+  Options.withAlias('a'),
+  Options.withDescription('Application ID to deploy to (overrides the linked application)'),
+  Options.optional
+);
+
+export const deployCommand = Command.make('deploy', { app: appOption }, ({ app }) =>
   Effect.gen(function* () {
     const projectConfig = yield* ProjectConfigService;
     const deploymentApi = yield* DeploymentApiService;
     const archiveService = yield* ArchiveService;
+    const projectLink = yield* ProjectLinkService;
     const pathService = yield* Path.Path;
 
     const cwd = process.cwd();
+
+    // Resolve the target application: an explicit --app wins, otherwise the app
+    // linked to this directory via `gigadrive link`.
+    const applicationId = yield* Option.match(app, {
+      onSome: (id) => Effect.succeed(id),
+      onNone: () => projectLink.resolve(cwd).pipe(Effect.map((link) => link.applicationId)),
+    });
 
     // Resolve and validate config
     yield* Effect.log('Starting deploy command');
@@ -24,7 +39,7 @@ export const deployCommand = Command.make('deploy', {}, () =>
 
     // Create deployment
     yield* Console.log('Creating deployment...');
-    const deploymentId = yield* deploymentApi.createDeployment('test'); // TODO: real application ID
+    const deploymentId = yield* deploymentApi.createDeployment(applicationId);
     yield* Console.log(`Deployment ID: ${deploymentId}`);
 
     // Create and upload archive
@@ -48,6 +63,8 @@ export const deployCommand = Command.make('deploy', {}, () =>
     yield* pollDeployment(deploymentId);
   }).pipe(
     Effect.catchTags({
+      ProjectNotLinkedError: (err) => Console.error(err.message).pipe(Effect.andThen(Effect.fail(err))),
+      ProjectLinkReadError: (err) => Console.error(err.message).pipe(Effect.andThen(Effect.fail(err))),
       ConfigNotFoundError: (err) => Console.error(err.message).pipe(Effect.andThen(Effect.fail(err))),
       ConfigParseError: (err) =>
         Console.error(`Config parse error: ${err.message}`).pipe(Effect.andThen(Effect.fail(err))),
@@ -165,7 +182,17 @@ const pollDeployment = (deploymentId: DeploymentId) =>
 
         // Check terminal states
         if (newStatus === 'ACTIVE') {
-          yield* Console.log(`Deployed to https://${deploymentId}.gigadrivedev.com`);
+          // Print the real per-deployment `*.gigadrive.app` hostname. Hostname
+          // lookup is best-effort — a failure here must not fail a successful deploy.
+          const hostnames = yield* deploymentApi
+            .getHostnames(deploymentId)
+            .pipe(Effect.catchTag('DeploymentHostnamesFetchError', () => Effect.succeed([])));
+          const active = hostnames.find((h) => h.active) ?? hostnames.at(0);
+          if (active) {
+            yield* Console.log(`Deployed to https://${active.hostname}`);
+          } else {
+            yield* Console.log('Deployment is live.');
+          }
           return yield* Effect.fail('done' as const);
         }
 

--- a/packages/cli/src/domain.ts
+++ b/packages/cli/src/domain.ts
@@ -54,3 +54,13 @@ export const StoredAuthData = Schema.Struct({
   tokenExpirationTime: Schema.optional(Schema.Number),
 });
 export type StoredAuthData = Schema.Schema.Type<typeof StoredAuthData>;
+
+// ---------------------------------------------------------------------------
+// Project link (.gigadrive/project.json) — links a working directory to an app
+// ---------------------------------------------------------------------------
+
+export const ProjectLink = Schema.Struct({
+  applicationId: Schema.String,
+  organizationId: Schema.optional(Schema.String),
+});
+export type ProjectLink = Schema.Schema.Type<typeof ProjectLink>;

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -43,12 +43,41 @@ export class UserInfoFetchError extends Schema.TaggedError<UserInfoFetchError>()
 }) {}
 
 // ---------------------------------------------------------------------------
+// API errors
+// ---------------------------------------------------------------------------
+
+/** A request to the Gigadrive Network API failed. Wraps the SDK's `ApiError`. */
+export class ApiRequestError extends Schema.TaggedError<ApiRequestError>()('ApiRequestError', {
+  message: Schema.String,
+  statusCode: Schema.optional(Schema.Number),
+  code: Schema.optional(Schema.String),
+}) {}
+
+// ---------------------------------------------------------------------------
 // Project errors
 // ---------------------------------------------------------------------------
 
 export class ConfigNotFoundError extends Schema.TaggedError<ConfigNotFoundError>()('ConfigNotFoundError', {
   message: Schema.String,
   directory: Schema.String,
+}) {}
+
+/** The project directory has no `.gigadrive/project.json` link. */
+export class ProjectNotLinkedError extends Schema.TaggedError<ProjectNotLinkedError>()('ProjectNotLinkedError', {
+  message: Schema.String,
+  directory: Schema.String,
+}) {}
+
+/** Failed to read or parse `.gigadrive/project.json`. */
+export class ProjectLinkReadError extends Schema.TaggedError<ProjectLinkReadError>()('ProjectLinkReadError', {
+  message: Schema.String,
+  cause: Schema.optional(Schema.String),
+}) {}
+
+/** Failed to write `.gigadrive/project.json`. */
+export class ProjectLinkWriteError extends Schema.TaggedError<ProjectLinkWriteError>()('ProjectLinkWriteError', {
+  message: Schema.String,
+  cause: Schema.optional(Schema.String),
 }) {}
 
 export class ConfigParseError extends Schema.TaggedError<ConfigParseError>()('ConfigParseError', {
@@ -134,6 +163,13 @@ export class DeploymentStatusError extends Schema.TaggedError<DeploymentStatusEr
 
 export class DeploymentLogsFetchError extends Schema.TaggedError<DeploymentLogsFetchError>()(
   'DeploymentLogsFetchError',
+  {
+    message: Schema.String,
+  }
+) {}
+
+export class DeploymentHostnamesFetchError extends Schema.TaggedError<DeploymentHostnamesFetchError>()(
+  'DeploymentHostnamesFetchError',
   {
     message: Schema.String,
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,11 +2,19 @@ import { Command } from '@effect/cli';
 import { NodeContext, NodeRuntime } from '@effect/platform-node';
 import { NetworkConfigLive } from '@gigadrive/network-config';
 import { Effect, Layer, LogLevel, Logger } from 'effect';
+import pkg from '../package.json';
+import { aiCommand } from './commands/ai';
+import { appsCommand } from './commands/apps';
 import { buildCommand } from './commands/build';
 import { debugCommand } from './commands/debug';
+import { deploymentsCommand } from './commands/deployments';
+import { envCommand } from './commands/env';
+import { linkCommand, unlinkCommand } from './commands/link';
 import { loginCommand } from './commands/login';
+import { logoutCommand } from './commands/logout';
 import { platformCommand } from './commands/platform';
 import { whoamiCommand } from './commands/whoami';
+import { ApiClientService } from './services/api-client';
 import { ArchiveService } from './services/archive';
 import { AuthService } from './services/auth';
 import { AuthStorageService } from './services/auth-storage';
@@ -14,13 +22,27 @@ import { DeploymentApiService } from './services/deployment-api';
 import { OAuthConfigService } from './services/oauth-config';
 import { PackageManagerService } from './services/package-manager';
 import { ProjectConfigService } from './services/project-config';
+import { ProjectLinkService } from './services/project-link';
 
 // ---------------------------------------------------------------------------
 // Root command with subcommands
 // ---------------------------------------------------------------------------
 
 const gigadrive = Command.make('gigadrive', {}, () => Effect.void).pipe(
-  Command.withSubcommands([loginCommand, whoamiCommand, buildCommand, debugCommand, platformCommand])
+  Command.withSubcommands([
+    loginCommand,
+    logoutCommand,
+    whoamiCommand,
+    linkCommand,
+    unlinkCommand,
+    appsCommand,
+    envCommand,
+    deploymentsCommand,
+    aiCommand,
+    buildCommand,
+    debugCommand,
+    platformCommand,
+  ])
 );
 
 // ---------------------------------------------------------------------------
@@ -29,7 +51,7 @@ const gigadrive = Command.make('gigadrive', {}, () => Effect.void).pipe(
 
 const cli = Command.run(gigadrive, {
   name: 'Gigadrive CLI',
-  version: '2.0.0',
+  version: pkg.version,
 });
 
 // ---------------------------------------------------------------------------
@@ -42,12 +64,14 @@ const BaseServices = Layer.mergeAll(
   PackageManagerService.Default,
   ArchiveService.Default,
   NetworkConfigLive,
-  ProjectConfigService.Default
+  ProjectConfigService.Default,
+  ProjectLinkService.Default
 ).pipe(Layer.provideMerge(AuthService.Default));
 
+const ApiClientLive = Layer.provide(ApiClientService.Default, BaseServices);
 const DeploymentApiLive = Layer.provide(DeploymentApiService.Default, BaseServices);
 
-const ServicesLive = Layer.mergeAll(BaseServices, DeploymentApiLive);
+const ServicesLive = Layer.mergeAll(BaseServices, ApiClientLive, DeploymentApiLive);
 
 const AppLive = Layer.mergeAll(ServicesLive, Logger.minimumLogLevel(LogLevel.Info)).pipe(
   Layer.provideMerge(NodeContext.layer)

--- a/packages/cli/src/services/api-client.test.ts
+++ b/packages/cli/src/services/api-client.test.ts
@@ -1,0 +1,99 @@
+import { ConfigProvider, Effect, Layer, Logger, LogLevel } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotAuthenticatedError } from '../errors';
+import { ApiClientService } from './api-client';
+import { AuthService } from './auth';
+
+const BASE_URL = 'https://api.example.com';
+
+type AuthOverrides = { getAccessToken?: AuthService['getAccessToken'] };
+
+const makeTestLayer = (auth: AuthOverrides = {}) => {
+  const configLayer = Layer.setConfigProvider(ConfigProvider.fromMap(new Map([['GIGADRIVE_API_BASE_URL', BASE_URL]])));
+
+  const mockAuthService = Layer.succeed(AuthService, {
+    login: Effect.succeed(true as const),
+    logout: Effect.void,
+    getAccessToken: auth.getAccessToken ?? Effect.succeed('test-auth-token'),
+    getUserInfo: Effect.succeed({}),
+    refreshAccessToken: Effect.succeed(true as const),
+    inferUserName: () => 'test-user',
+    _tag: 'AuthService',
+  } as unknown as AuthService);
+
+  return Layer.provide(ApiClientService.Default, Layer.mergeAll(configLayer, mockAuthService)).pipe(
+    Layer.provideMerge(Logger.minimumLogLevel(LogLevel.None))
+  );
+};
+
+const lastFetchCall = () => {
+  const calls = vi.mocked(globalThis.fetch).mock.calls;
+  const [url, init] = calls[calls.length - 1]!;
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries((init?.headers ?? {}) as Record<string, string>)) {
+    headers[key.toLowerCase()] = value;
+  }
+  return { url: String(url), method: init?.method, headers };
+};
+
+const listApps = Effect.gen(function* () {
+  const client = yield* ApiClientService;
+  return yield* client.request((c) => c.applications.list());
+});
+
+describe('ApiClientService', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('authenticates requests with a bearer token and the configured base URL', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ items: [], total: 0 }), { status: 200 }));
+
+    const result = await Effect.runPromise(Effect.provide(listApps, makeTestLayer()));
+
+    expect(result.total).toBe(0);
+    const call = lastFetchCall();
+    expect(call.url).toBe(`${BASE_URL}/applications`);
+    expect(call.method).toBe('GET');
+    expect(call.headers.authorization).toBe('Bearer test-auth-token');
+  });
+
+  it('maps a non-OK response to ApiRequestError with the status code', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'boom' }), { status: 500 }));
+
+    const result = await Effect.runPromise(
+      Effect.provide(listApps, makeTestLayer()).pipe(
+        Effect.catchTag('ApiRequestError', (err) => Effect.succeed({ status: err.statusCode, message: err.message }))
+      )
+    );
+
+    expect(result).toMatchObject({ status: 500, message: 'boom' });
+  });
+
+  it('propagates NotAuthenticatedError when the user is not logged in', async () => {
+    globalThis.fetch = vi.fn();
+
+    const layer = makeTestLayer({
+      getAccessToken: Effect.fail(new NotAuthenticatedError({ message: 'please log in' })),
+    });
+
+    const result = await Effect.runPromise(
+      Effect.provide(listApps, layer).pipe(
+        Effect.catchTag('NotAuthenticatedError', (err) =>
+          Effect.succeed({ _tag: 'caught' as const, message: err.message })
+        )
+      )
+    );
+
+    expect(result).toMatchObject({ _tag: 'caught', message: 'please log in' });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/services/api-client.ts
+++ b/packages/cli/src/services/api-client.ts
@@ -1,0 +1,62 @@
+import { ApiError, GigadriveClient } from '@gigadrive/sdk';
+import { Config, Effect } from 'effect';
+import { ApiRequestError } from '../errors';
+import { AuthService } from './auth';
+
+// ---------------------------------------------------------------------------
+// ApiClientService
+//
+// A single, shared factory for the `@gigadrive/sdk` client. Every command that
+// talks to the Gigadrive Network API obtains its client here so authentication
+// (a fresh access token from AuthService) and the base URL are configured in
+// exactly one place.
+// ---------------------------------------------------------------------------
+
+const ApiBaseUrl = Config.string('GIGADRIVE_API_BASE_URL').pipe(Config.withDefault('https://api.gigadrive.network'));
+
+/** Map any error thrown by an SDK call into a tagged {@link ApiRequestError}. */
+const toApiRequestError = (error: unknown): ApiRequestError => {
+  if (error instanceof ApiError) {
+    return new ApiRequestError({ message: error.message, statusCode: error.status, code: error.code });
+  }
+  return new ApiRequestError({ message: error instanceof Error ? error.message : String(error) });
+};
+
+export class ApiClientService extends Effect.Service<ApiClientService>()('ApiClientService', {
+  accessors: true,
+
+  effect: Effect.gen(function* () {
+    const baseUrl = yield* ApiBaseUrl;
+    const authService = yield* AuthService;
+
+    /**
+     * Build a `GigadriveClient` authenticated with a fresh access token.
+     * Fails with `NotAuthenticatedError` when the user is not logged in.
+     */
+    const getClient = Effect.gen(function* () {
+      const token = yield* authService.getAccessToken;
+      return new GigadriveClient({ bearerToken: token, baseUrl });
+    });
+
+    /**
+     * Run an SDK call against an authenticated client, translating rejected
+     * promises into a tagged {@link ApiRequestError}. This is the ergonomic
+     * entry point for command handlers.
+     *
+     * @example
+     * ```ts
+     * const { items } = yield* apiClient.request((client) => client.applications.list());
+     * ```
+     */
+    const request = <A>(f: (client: GigadriveClient) => Promise<A>) =>
+      Effect.gen(function* () {
+        const client = yield* getClient;
+        return yield* Effect.tryPromise({
+          try: () => f(client),
+          catch: toApiRequestError,
+        });
+      });
+
+    return { getClient, request };
+  }),
+}) {}

--- a/packages/cli/src/services/deployment-api.ts
+++ b/packages/cli/src/services/deployment-api.ts
@@ -1,9 +1,9 @@
-import { GigadriveClient } from '@gigadrive/sdk';
-import { Config, Effect } from 'effect';
+import { Effect } from 'effect';
 import type { DeploymentId, UploadId } from '../domain';
 import {
   DeploymentAuthError,
   DeploymentCreateError,
+  DeploymentHostnamesFetchError,
   DeploymentLogsFetchError,
   DeploymentStatusError,
   PresignedUrlError,
@@ -11,27 +11,26 @@ import {
   UploadPartError,
   UploadStartError,
 } from '../errors';
-import { AuthService } from './auth';
+import { ApiClientService } from './api-client';
 
 // ---------------------------------------------------------------------------
 // DeploymentApiService
+//
+// A thin, deployment-focused wrapper over the shared ApiClientService. It keeps
+// its own tagged errors (DeploymentAuthError, UploadPartError, …) so the deploy
+// command's error handling and spans are unchanged.
 // ---------------------------------------------------------------------------
-
-const ApiBaseUrl = Config.string('GIGADRIVE_API_BASE_URL').pipe(Config.withDefault('http://localhost:3000'));
 
 export class DeploymentApiService extends Effect.Service<DeploymentApiService>()('DeploymentApiService', {
   accessors: true,
+  dependencies: [ApiClientService.Default],
 
   effect: Effect.gen(function* () {
-    const baseUrl = yield* ApiBaseUrl;
-    const authService = yield* AuthService;
+    const apiClient = yield* ApiClientService;
 
-    const getClient: Effect.Effect<GigadriveClient, DeploymentAuthError> = Effect.gen(function* () {
-      const token: string = yield* authService.getAccessToken.pipe(
-        Effect.mapError((err) => new DeploymentAuthError({ message: `Authentication failed: ${err.message}` }))
-      );
-      return new GigadriveClient({ bearerToken: token, baseUrl });
-    });
+    const getClient = apiClient.getClient.pipe(
+      Effect.mapError((err) => new DeploymentAuthError({ message: `Authentication failed: ${err.message}` }))
+    );
 
     const createDeployment = Effect.fn('DeploymentApiService.createDeployment')(function* (applicationId: string) {
       yield* Effect.annotateCurrentSpan('applicationId', applicationId);
@@ -157,6 +156,19 @@ export class DeploymentApiService extends Effect.Service<DeploymentApiService>()
       return result;
     });
 
+    const getHostnames = Effect.fn('DeploymentApiService.getHostnames')(function* (deploymentId: DeploymentId) {
+      const client = yield* getClient;
+      const result = yield* Effect.tryPromise({
+        try: () => client.deployments.getHostnames(deploymentId),
+        catch: (error) =>
+          new DeploymentHostnamesFetchError({
+            message: `Failed to get hostnames: ${error instanceof Error ? error.message : String(error)}`,
+          }),
+      });
+
+      return result.items;
+    });
+
     return {
       createDeployment,
       startMultipartUpload,
@@ -165,6 +177,7 @@ export class DeploymentApiService extends Effect.Service<DeploymentApiService>()
       completeUpload,
       getDeploymentStatus,
       getLogs,
+      getHostnames,
     };
   }),
 }) {}

--- a/packages/cli/src/services/project-link.test.ts
+++ b/packages/cli/src/services/project-link.test.ts
@@ -1,0 +1,132 @@
+import { FileSystem, Path } from '@effect/platform';
+import { Effect, Layer, Logger, LogLevel, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { ProjectLinkService } from './project-link';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeMockFileSystem = (files: Map<string, string>) =>
+  ({
+    exists: (path: string) => Effect.succeed(files.has(path)),
+    readFileString: (path: string) =>
+      files.has(path)
+        ? Effect.succeed(files.get(path)!)
+        : Effect.fail({ _tag: 'SystemError' as const, message: 'ENOENT' }),
+    writeFileString: (path: string, content: string) =>
+      Effect.sync(() => {
+        files.set(path, content);
+      }),
+    remove: (path: string) =>
+      Effect.sync(() => {
+        files.delete(path);
+      }),
+    makeDirectory: () => Effect.void,
+  }) as unknown as FileSystem.FileSystem;
+
+const mockPath: Path.Path = {
+  join: (...segments: string[]) => segments.join('/'),
+} as unknown as Path.Path;
+
+const makeTestLayer = (initialFiles: Record<string, string> = {}) => {
+  const files = new Map(Object.entries(initialFiles));
+  const platformLayer = Layer.mergeAll(
+    Layer.succeed(FileSystem.FileSystem, makeMockFileSystem(files)),
+    Layer.succeed(Path.Path, mockPath)
+  );
+  const layer = Layer.provide(ProjectLinkService.Default, platformLayer).pipe(
+    Layer.provideMerge(Logger.minimumLogLevel(LogLevel.None))
+  );
+  return { layer, files };
+};
+
+const PROJECT = '/project';
+const LINK_PATH = `${PROJECT}/.gigadrive/project.json`;
+
+// ---------------------------------------------------------------------------
+// load / resolve
+// ---------------------------------------------------------------------------
+
+describe('ProjectLinkService.load', () => {
+  it('returns None when the directory is not linked', async () => {
+    const { layer } = makeTestLayer();
+    const result = await Effect.runPromise(Effect.provide(ProjectLinkService.load(PROJECT), layer));
+    expect(Option.isNone(result)).toBe(true);
+  });
+
+  it('returns the parsed link when project.json exists', async () => {
+    const { layer } = makeTestLayer({
+      [LINK_PATH]: JSON.stringify({ applicationId: 'app-1', organizationId: 'org-1' }),
+    });
+    const result = await Effect.runPromise(Effect.provide(ProjectLinkService.load(PROJECT), layer));
+    expect(Option.isSome(result)).toBe(true);
+    if (Option.isSome(result)) {
+      expect(result.value.applicationId).toBe('app-1');
+      expect(result.value.organizationId).toBe('org-1');
+    }
+  });
+
+  it('fails with ProjectLinkReadError on invalid JSON', async () => {
+    const { layer } = makeTestLayer({ [LINK_PATH]: 'not-json' });
+    const result = await Effect.runPromise(
+      Effect.provide(ProjectLinkService.load(PROJECT), layer).pipe(
+        Effect.catchTag('ProjectLinkReadError', (err) => Effect.succeed({ message: err.message }))
+      )
+    );
+    expect(result).toMatchObject({ message: expect.stringContaining('invalid JSON') });
+  });
+
+  it('fails with ProjectLinkReadError on invalid schema', async () => {
+    const { layer } = makeTestLayer({ [LINK_PATH]: JSON.stringify({ nope: true }) });
+    const result = await Effect.runPromise(
+      Effect.provide(ProjectLinkService.load(PROJECT), layer).pipe(
+        Effect.catchTag('ProjectLinkReadError', (err) => Effect.succeed({ message: err.message }))
+      )
+    );
+    expect(result).toMatchObject({ message: expect.stringContaining('invalid schema') });
+  });
+});
+
+describe('ProjectLinkService.resolve', () => {
+  it('fails with ProjectNotLinkedError when not linked', async () => {
+    const { layer } = makeTestLayer();
+    const result = await Effect.runPromise(
+      Effect.provide(ProjectLinkService.resolve(PROJECT), layer).pipe(
+        Effect.catchTag('ProjectNotLinkedError', (err) =>
+          Effect.succeed({ _tag: 'caught' as const, dir: err.directory })
+        )
+      )
+    );
+    expect(result).toMatchObject({ _tag: 'caught', dir: PROJECT });
+  });
+
+  it('returns the link when linked', async () => {
+    const { layer } = makeTestLayer({ [LINK_PATH]: JSON.stringify({ applicationId: 'app-9' }) });
+    const result = await Effect.runPromise(Effect.provide(ProjectLinkService.resolve(PROJECT), layer));
+    expect(result.applicationId).toBe('app-9');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// save / remove
+// ---------------------------------------------------------------------------
+
+describe('ProjectLinkService.save', () => {
+  it('writes project.json with the application and organization', async () => {
+    const { layer, files } = makeTestLayer();
+    await Effect.runPromise(
+      Effect.provide(ProjectLinkService.save(PROJECT, { applicationId: 'app-2', organizationId: 'org-2' }), layer)
+    );
+    expect(files.has(LINK_PATH)).toBe(true);
+    expect(JSON.parse(files.get(LINK_PATH)!)).toEqual({ applicationId: 'app-2', organizationId: 'org-2' });
+  });
+});
+
+describe('ProjectLinkService.remove', () => {
+  it('removes an existing link file', async () => {
+    const { layer, files } = makeTestLayer({ [LINK_PATH]: JSON.stringify({ applicationId: 'app-3' }) });
+    await Effect.runPromise(Effect.provide(ProjectLinkService.remove(PROJECT), layer));
+    expect(files.has(LINK_PATH)).toBe(false);
+  });
+});

--- a/packages/cli/src/services/project-link.ts
+++ b/packages/cli/src/services/project-link.ts
@@ -1,0 +1,111 @@
+import { FileSystem, Path } from '@effect/platform';
+import { Effect, Option, Schema } from 'effect';
+import type { ProjectLink } from '../domain';
+import { ProjectLink as ProjectLinkSchema } from '../domain';
+import { ProjectLinkReadError, ProjectLinkWriteError, ProjectNotLinkedError } from '../errors';
+
+// ---------------------------------------------------------------------------
+// ProjectLinkService
+//
+// Links a working directory to a Gigadrive application by persisting the choice
+// in `<projectFolder>/.gigadrive/project.json`. Commands read the linked
+// application so they don't require an explicit `--app` on every invocation.
+// ---------------------------------------------------------------------------
+
+const LINK_DIR = '.gigadrive';
+const LINK_FILE = 'project.json';
+
+export class ProjectLinkService extends Effect.Service<ProjectLinkService>()('ProjectLinkService', {
+  accessors: true,
+
+  effect: Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const pathService = yield* Path.Path;
+
+    const linkDir = (projectFolder: string) => pathService.join(projectFolder, LINK_DIR);
+    const linkFile = (projectFolder: string) => pathService.join(projectFolder, LINK_DIR, LINK_FILE);
+
+    /** Load the project link, returning `Option.none` when the directory is not linked. */
+    const load = Effect.fn('ProjectLinkService.load')(function* (projectFolder: string) {
+      const file = linkFile(projectFolder);
+
+      const exists = yield* fs
+        .exists(file)
+        .pipe(Effect.mapError(() => new ProjectLinkReadError({ message: 'Failed to check project link existence' })));
+      if (!exists) return Option.none<ProjectLink>();
+
+      const data = yield* fs
+        .readFileString(file, 'utf8')
+        .pipe(Effect.mapError(() => new ProjectLinkReadError({ message: 'Failed to read project link file' })));
+
+      const json = yield* Effect.try({
+        try: () => JSON.parse(data) as unknown,
+        catch: () => new ProjectLinkReadError({ message: `${LINK_DIR}/${LINK_FILE} contains invalid JSON` }),
+      });
+
+      const link = yield* Schema.decodeUnknown(ProjectLinkSchema)(json).pipe(
+        Effect.mapError(() => new ProjectLinkReadError({ message: `${LINK_DIR}/${LINK_FILE} has an invalid schema` }))
+      );
+
+      return Option.some(link);
+    });
+
+    /** Load the project link, failing with `ProjectNotLinkedError` when absent. */
+    const resolve = Effect.fn('ProjectLinkService.resolve')(function* (projectFolder: string) {
+      const link = yield* load(projectFolder);
+      return yield* Option.match(link, {
+        onNone: () =>
+          Effect.fail(
+            new ProjectNotLinkedError({
+              message: 'This directory is not linked to an application. Run "gigadrive link" first.',
+              directory: projectFolder,
+            })
+          ),
+        onSome: (value) => Effect.succeed(value),
+      });
+    });
+
+    /** Persist the project link, creating `.gigadrive/` if needed. */
+    const save = Effect.fn('ProjectLinkService.save')(function* (projectFolder: string, link: ProjectLink) {
+      yield* fs
+        .makeDirectory(linkDir(projectFolder), { recursive: true })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new ProjectLinkWriteError({ message: 'Failed to create .gigadrive directory', cause: String(error) })
+          )
+        );
+      yield* fs
+        .writeFileString(linkFile(projectFolder), `${JSON.stringify(link, null, 2)}\n`)
+        .pipe(
+          Effect.mapError(
+            (error) => new ProjectLinkWriteError({ message: 'Failed to write project link file', cause: String(error) })
+          )
+        );
+      yield* Effect.log('Project link saved', { applicationId: link.applicationId });
+    });
+
+    /** Remove the project link file, treating a missing file as success. */
+    const remove = Effect.fn('ProjectLinkService.remove')(function* (projectFolder: string) {
+      yield* fs.remove(linkFile(projectFolder)).pipe(
+        Effect.mapError((error) => {
+          const cause = error instanceof Error ? error : (error as { error?: Error }).error;
+          const code = cause && typeof cause === 'object' && 'code' in cause ? (cause as { code: string }).code : '';
+          return { isNotFound: code === 'ENOENT' || String(error).includes('ENOENT'), original: error };
+        }),
+        Effect.catchAll((mapped) =>
+          mapped.isNotFound
+            ? Effect.void
+            : Effect.fail(
+                new ProjectLinkWriteError({
+                  message: 'Failed to remove project link file',
+                  cause: String(mapped.original),
+                })
+              )
+        )
+      );
+    });
+
+    return { load, resolve, save, remove };
+  }),
+}) {}

--- a/packages/sdk/src/resources/applications.test.ts
+++ b/packages/sdk/src/resources/applications.test.ts
@@ -6,6 +6,7 @@ const createMockHttpClient = (): HttpClient =>
   ({
     get: vi.fn().mockResolvedValue({ items: [], total: 0 }),
     post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
     patch: vi.fn().mockResolvedValue({}),
     delete: vi.fn().mockResolvedValue(undefined),
   }) as unknown as HttpClient;
@@ -33,6 +34,24 @@ describe('ApplicationsResource', () => {
 
     await resource.hostnames('app-1');
     expect(http.get).toHaveBeenCalledWith('/applications/app-1/hostnames');
+  });
+
+  it('should check production hostname availability', async () => {
+    const http = createMockHttpClient();
+    const resource = new ApplicationsResource(http);
+
+    await resource.checkHostnameAvailability('app-1', 'my-app');
+    expect(http.get).toHaveBeenCalledWith('/applications/app-1/hostname/availability', {
+      query: { label: 'my-app' },
+    });
+  });
+
+  it('should set the production hostname', async () => {
+    const http = createMockHttpClient();
+    const resource = new ApplicationsResource(http);
+
+    await resource.setProductionHostname('app-1', 'my-app');
+    expect(http.put).toHaveBeenCalledWith('/applications/app-1/hostname', { label: 'my-app' });
   });
 
   it('should expose envVars sub-resource', async () => {

--- a/packages/sdk/src/resources/applications.ts
+++ b/packages/sdk/src/resources/applications.ts
@@ -3,7 +3,7 @@ import { ApplicationEnvVarsResource } from './application-env-vars';
 import { ApplicationRequestsResource } from './application-requests';
 import { ApplicationStorageResource } from './application-storage';
 import { BaseResource } from './base-resource';
-import type { ApplicationHostnameList } from './hostnames';
+import type { ApplicationHostnameList, HostnameAvailability, SetProductionHostnameResult } from './hostnames';
 import type { Organization } from './organizations';
 
 /** A Gigadrive Network application, belonging to an {@link Organization}. */
@@ -123,5 +123,49 @@ export class ApplicationsResource extends BaseResource {
    */
   async hostnames(applicationId: string): Promise<ApplicationHostnameList> {
     return this.httpClient.get(`/applications/${applicationId}/hostnames`);
+  }
+
+  /**
+   * Check whether a candidate production hostname label is allowed and globally
+   * available before setting it with {@link setProductionHostname}.
+   *
+   * Requires the `network:applications:read` scope.
+   *
+   * @param applicationId - The application ID (UUID).
+   * @param label - The candidate production hostname label (e.g. `"my-app"`).
+   * @returns Whether the label is available, plus a `reason` when it is not.
+   *
+   * @example
+   * ```ts
+   * const { available, reason } = await client.applications.checkHostnameAvailability('app-id', 'my-app');
+   * if (!available) console.log(`Unavailable: ${reason}`);
+   * ```
+   */
+  async checkHostnameAvailability(applicationId: string, label: string): Promise<HostnameAvailability> {
+    return this.httpClient.get(`/applications/${applicationId}/hostname/availability`, {
+      query: { label },
+    });
+  }
+
+  /**
+   * Set the application's production hostname. The production alias
+   * `{label}.gigadrive.app` is re-pointed to the latest production deployment.
+   *
+   * Requires the `network:applications:write` scope. Deployment- and
+   * function-scoped tokens cannot change the production hostname.
+   *
+   * @param applicationId - The application ID (UUID).
+   * @param label - The production hostname label (e.g. `"my-app"`). It is
+   *   normalized (slugified) server-side.
+   * @returns The saved label, the resulting hostname, and whether it is live yet.
+   *
+   * @example
+   * ```ts
+   * const { hostname, live } = await client.applications.setProductionHostname('app-id', 'my-app');
+   * console.log(live ? `Live at ${hostname}` : `Reserved ${hostname} (deploy to go live)`);
+   * ```
+   */
+  async setProductionHostname(applicationId: string, label: string): Promise<SetProductionHostnameResult> {
+    return this.httpClient.put(`/applications/${applicationId}/hostname`, { label });
   }
 }

--- a/packages/sdk/src/resources/hostnames.ts
+++ b/packages/sdk/src/resources/hostnames.ts
@@ -25,3 +25,25 @@ export interface ApplicationHostnameList extends Paginated<Hostname> {
   /** The application's production hostname label (`{label}.gigadrive.app`), or `null` if none is set. */
   label: string | null;
 }
+
+/** The result of checking whether a production hostname label is available. */
+export interface HostnameAvailability {
+  /** Whether the label is allowed and globally available. */
+  available: boolean;
+  /** When {@link available} is `false`, a human-readable reason (e.g. the label is reserved or already taken). */
+  reason?: string;
+}
+
+/** The result of setting an application's production hostname. */
+export interface SetProductionHostnameResult {
+  /** The normalized production label that was saved. */
+  label: string;
+  /** The resulting `{label}.gigadrive.app` hostname. */
+  hostname: string;
+  /**
+   * Whether the hostname now routes traffic. `false` when the label is reserved
+   * but no active production deployment exists yet — the URL becomes live after
+   * the next production deployment.
+   */
+  live: boolean;
+}

--- a/packages/sdk/src/resources/index.ts
+++ b/packages/sdk/src/resources/index.ts
@@ -48,7 +48,7 @@ export type {
 
 export type { CreateEnvVarInput, EnvVar, UpdateEnvVarInput } from './env-vars';
 
-export type { ApplicationHostnameList, Hostname } from './hostnames';
+export type { ApplicationHostnameList, Hostname, HostnameAvailability, SetProductionHostnameResult } from './hostnames';
 
 export { OrganizationsResource } from './organizations';
 export type { Organization } from './organizations';


### PR DESCRIPTION
## Summary
- Add SDK support for application hostname availability checks and production hostname updates.
- Expand the CLI with new `apps`, `env`, `deployments`, `ai`, and `logout` commands.
- Introduce project linking via `.gigadrive/project.json` so resource commands and deploys can target the linked app/org.
- Centralize authenticated API client creation in `ApiClientService` and route deployment flows through it.
- Update deploy output to use the real linked application hostname on success.

## Testing
- Not run (changes reviewed from diff only).
- Existing/added Vitest coverage was added for API client, project linking, and SDK hostname/application resources.
- CI should cover `pnpm test`, `pnpm lint`, `pnpm format`, and `pnpm typecheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hostname management for applications, including checking availability and setting a production hostname.
  * Expanded the CLI with new commands for apps, environments, deployments, AI usage tools, and logout.
  * Added project linking so the CLI can remember the active application for a directory.

* **Bug Fixes**
  * Deployment output now shows the real live hostname when available.
  * CLI commands now better handle missing links, authentication issues, and API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->